### PR TITLE
fix: make lifespan require opacity

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4762,17 +4762,12 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
         const fade = opt.fade ?? 0;
         return {
             id: "lifespan",
+            require: [ "opacity" ],
             async add(this: GameObj<OpacityComp>) {
                 await wait(time);
-                // TODO: this secretively requires opacity comp, make opacity on every game obj?
-                if (fade > 0 && this.opacity) {
-                    await tween(
-                        this.opacity,
-                        0,
-                        fade,
-                        (a) => this.opacity = a,
-                        easings.linear,
-                    );
+                this.opacity = this.opacity ?? 1
+                if (fade > 0) {
+                    await tween(this.opacity, 0, fade, (a) => this.opacity = a, easings.linear);
                 }
                 this.destroy();
             },


### PR DESCRIPTION
PR originally made by @tejaboy in the original kaboom repository
https://github.com/replit/kaboom/pull/826
Added to this fork because it didn't got merged on the old-kaboom and that person won't probably make it here, so i might as well
