### PR TITLE
fix: area displays size on inspect

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -3847,6 +3847,10 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
                     return area.transform(game.cam.transform);
                 }
             },
+
+            inspect() {
+                return `(${(this.area.scale.x).toFixed(1)}, ${(this.area.scale.y).toFixed(1)})`;
+            }
         };
     }
 


### PR DESCRIPTION
area apparently used to display "area" when inspecting, now it displays the vector size, in the same format as pos