### PR TITLE
feat: added debugKey

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4883,7 +4883,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
         });
 
         if (gopt.debug !== false) {
-            app.onKeyPress("f1", () => debug.inspect = !debug.inspect);
+            app.onKeyPress(!gopt.debugKey ? "f1" : gopt.debugKey, () => debug.inspect = !debug.inspect);
             app.onKeyPress("f2", () => debug.clearLog());
             app.onKeyPress("f8", () => debug.paused = !debug.paused);
             app.onKeyPress("f7", () => {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -707,6 +707,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
         // misc
         gravity: 0,
         scenes: {},
+        currentScene: null,
 
         // on screen log
         logs: [],
@@ -3471,12 +3472,18 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
 
             game.scenes[name](...args);
         });
+
+        game.currentScene = name;
     }
 
     function onSceneLeave(
         action: (newScene?: string) => void,
     ): EventController {
         return game.events.on("sceneLeave", action);
+    }
+
+    function getSceneName() {
+        return game.currentScene;
     }
 
     function getData<T>(key: string, def?: T): T {
@@ -5146,6 +5153,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
         debug,
         // scene
         scene,
+        getSceneName,
         go,
         onSceneLeave,
         // level

--- a/src/types.ts
+++ b/src/types.ts
@@ -3261,6 +3261,10 @@ export interface KaboomOpt<T extends PluginList<any> = any> {
      */
     debug?: boolean;
     /**
+     * Key used to toggle debug mode (default "f1")
+     */
+    debugKey?: Key;
+    /**
      * Default font (defaults to "monospace").
      */
     font?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1322,6 +1322,14 @@ export interface KaboomCtx {
      */
     onSceneLeave(action: (newScene?: string) => void): EventController;
     /**
+    /**
+     * Gets the name of the current scene.
+     *
+     * @since v3000.0
+     * @group Scenes
+     */
+    getSceneName(): string;
+    /**
      * Sets the root for all subsequent resource urls.
      *
      * @example


### PR DESCRIPTION
Added a property in kaboomOpt where you can set the key you want to use to toggle debug mode, default is "f1", couldn't find where defaults for kaboomOpt are so i just checked in the actual key detecting:
`app.onKeyPress(!gopt.debugKey ? "f1" : gopt.debugKey, () => debug.inspect = !debug.inspect);`
