### PR TITLE
feat: added debugKey

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4883,7 +4883,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
         });
 
         if (gopt.debug !== false) {
-            app.onKeyPress("f1", () => debug.inspect = !debug.inspect);
+            app.onKeyPress(!gopt.debugKey ? "f1" : gopt.debugKey, () => debug.inspect = !debug.inspect);
             app.onKeyPress("f2", () => debug.clearLog());
             app.onKeyPress("f8", () => debug.paused = !debug.paused);
             app.onKeyPress("f7", () => {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4883,7 +4883,7 @@ export default (gopt: KaboomOpt = {}): KaboomCtx => {
         });
 
         if (gopt.debug !== false) {
-            app.onKeyPress(!gopt.debugKey ? "f1" : gopt.debugKey, () => debug.inspect = !debug.inspect);
+            app.onKeyPress(gopt.debugKey ?? "f1", () => debug.inspect = !debug.inspect);
             app.onKeyPress("f2", () => debug.clearLog());
             app.onKeyPress("f8", () => debug.paused = !debug.paused);
             app.onKeyPress("f7", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3261,6 +3261,10 @@ export interface KaboomOpt<T extends PluginList<any> = any> {
      */
     debug?: boolean;
     /**
+     * key that toggles debug mode
+     */
+    debugKey?: Key;
+    /**
      * Default font (defaults to "monospace").
      */
     font?: string;


### PR DESCRIPTION
Added a property for kaboomOpt where you can set the key that toggles the debug mode, couldn't find where the defaults in kaboomOpt were defined so i just checked in the line that does the key checking
`app.onKeyPress(!gopt.debugKey ? "f1" : gopt.debugKey, () => debug.inspect = !debug.inspect);`

closes: https://github.com/marklovers/kaplay/issues/46