### PR TITLE
refactor: rename `kaboom`/`startGame` to `kaplay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v3001.0
 
-- renamed `kaboom` to `startGame` (you can still use `kaboom`)
+- renamed `kaboom()` to `kaplay()` (you can still use `kaboom*`)
 - added global raycast function and raycast method to level
 - added support for textured polygons
 - added support for concave polygon drawing

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Start playing around with it in the [Kaplayground](https://kaplay.pages.dev/)
 
 ```js
 // initialize context
-kaboom();
+kaplay();
 
 // define gravity
 setGravity(2400);
@@ -125,7 +125,7 @@ $ npm install kaplay
 ```js
 import kaboom from "kaplay";
 
-kaboom();
+kaplay();
 
 add([
     text("oh hi"),
@@ -148,7 +148,7 @@ This exports a global `kaboom` function
 ```html
 <script src="https://unpkg.com/kaplay@3001/dist/kaboom.js"></script>
 <script>
-kaboom()
+kaplay()
 </script>
 ```
 
@@ -157,7 +157,7 @@ or use with es modules
 ```html
 <script type="module">
 import kaboom from "https://unpkg.com/kaplay@3001/dist/kaboom.mjs"
-kaboom()
+kaplay()
 </script>
 ```
 

--- a/examples/add.js
+++ b/examples/add.js
@@ -1,7 +1,7 @@
 // Adding game objects to screen
 
 // Start a kaboom game
-startGame();
+kaplay();
 
 // Load a sprite asset from "sprites/bean.png", with the name "bean"
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/ai.js
+++ b/examples/ai.js
@@ -1,7 +1,7 @@
 // Use state() component to handle basic AI
 
 // Start kaboom
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/audio.js
+++ b/examples/audio.js
@@ -1,6 +1,6 @@
 // audio playback & control
 
-kaboom({
+kaplay({
     // Don't pause audio when tab is not active
     backgroundAudio: true,
     background: [0, 0, 0],

--- a/examples/bench.js
+++ b/examples/bench.js
@@ -1,6 +1,6 @@
 // bench marking sprite rendering performance
 
-kaboom();
+kaplay();
 
 loadSprite("bean", "sprites/bean.png");
 loadSprite("bag", "sprites/bag.png");

--- a/examples/burp.js
+++ b/examples/burp.js
@@ -1,5 +1,5 @@
 // Start the game in burp mode
-kaboom({
+kaplay({
     burp: true,
 });
 

--- a/examples/button.js
+++ b/examples/button.js
@@ -1,6 +1,6 @@
 // Simple Button UI
 
-kaboom({
+kaplay({
     background: [135, 62, 132],
 });
 

--- a/examples/camera.js
+++ b/examples/camera.js
@@ -1,7 +1,7 @@
 // Adjust camera / viewport
 
 // Start game
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/children.js
+++ b/examples/children.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 loadSprite("ghosty", "/sprites/ghosty.png");

--- a/examples/collision.js
+++ b/examples/collision.js
@@ -1,7 +1,7 @@
 // Collision handling
 
 // Start kaboom
-kaboom({
+kaplay({
     scale: 2,
 });
 

--- a/examples/component.js
+++ b/examples/component.js
@@ -1,6 +1,6 @@
 // Custom component
 
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 

--- a/examples/concert.js
+++ b/examples/concert.js
@@ -1,6 +1,6 @@
 // bean is holding a concert to celebrate kaboom2000!
 
-kaboom({
+kaplay({
     scale: 0.7,
     background: [128, 180, 255],
 });

--- a/examples/confetti.js
+++ b/examples/confetti.js
@@ -9,7 +9,7 @@ const DEF_SPIN = [2, 8];
 const DEF_SATURATION = 0.7;
 const DEF_LIGHTNESS = 0.6;
 
-kaboom();
+kaplay();
 
 function addConfetti(opt = {}) {
     const sample = (s) => typeof s === "function" ? s() : s;

--- a/examples/dialog.js
+++ b/examples/dialog.js
@@ -1,6 +1,6 @@
 // Simple dialogues
 
-kaboom({
+kaplay({
     background: [255, 209, 253],
 });
 

--- a/examples/doublejump.js
+++ b/examples/doublejump.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     background: [141, 183, 255],
 });
 

--- a/examples/drag.js
+++ b/examples/drag.js
@@ -1,6 +1,6 @@
 // Drag & drop interaction
 
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 

--- a/examples/draw.js
+++ b/examples/draw.js
@@ -1,6 +1,6 @@
 // Kaboom as pure rendering lib (no component / game obj etc.)
 
-kaboom();
+kaplay();
 loadSprite("bean", "/sprites/bean.png");
 
 loadShader(

--- a/examples/eatlove.js
+++ b/examples/eatlove.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 const fruits = [
     "apple",

--- a/examples/egg.js
+++ b/examples/egg.js
@@ -1,6 +1,6 @@
 // Egg minigames (yes, like Peppa)
 
-kaboom({
+kaplay({
     background: [135, 62, 132],
 });
 

--- a/examples/fadeIn.js
+++ b/examples/fadeIn.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 loadBean();
 
 // spawn a bean that takes a second to fade in
@@ -8,7 +8,7 @@ const bean = add([
     opacity(1), // opacity() component gives it opacity which is required for fadeIn
 ]);
 
-bean.fadeIn(1) // makes it fade in
+bean.fadeIn(1); // makes it fade in
 
 // spawn another bean that takes 5 seconds to fade in halfway
 // SPOOKY!
@@ -18,4 +18,4 @@ let spookyBean = add([
     opacity(0.5), // opacity() component gives it opacity which is required for fadeIn (set to 0.5 so it will be half transparent)
 ]);
 
-spookyBean.fadeIn(5) // makes it fade in (set to 5 so that it takes 5 seconds to fade in)
+spookyBean.fadeIn(5); // makes it fade in (set to 5 so that it takes 5 seconds to fade in)

--- a/examples/fall.js
+++ b/examples/fall.js
@@ -1,7 +1,7 @@
 // Build levels with addLevel()
 
 // Start game
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("coin", "/sprites/coin.png");

--- a/examples/flamebar.js
+++ b/examples/flamebar.js
@@ -1,7 +1,7 @@
 // Mario-like flamebar
 
 // Start kaboom
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/flappy.js
+++ b/examples/flappy.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 loadSound("score", "/examples/sounds/score.mp3");

--- a/examples/gamepad.js
+++ b/examples/gamepad.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 setGravity(2400);
 setBackground(0, 0, 0);
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/gravity.js
+++ b/examples/gravity.js
@@ -1,7 +1,7 @@
 // Responding to gravity & jumping
 
 // Start kaboom
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/hover.js
+++ b/examples/hover.js
@@ -1,6 +1,6 @@
 // Differeces between onHover and onHoverUpdate
 
-kaboom({
+kaplay({
     // Use logMax to see more messages on debug.log()
     logMax: 5,
 });

--- a/examples/kaboom.js
+++ b/examples/kaboom.js
@@ -1,4 +1,7 @@
+// You can still use kaboom() instead of kaplay()!
 kaboom();
+
 addKaboom(center());
+
 onKeyPress(() => addKaboom(mousePos()));
 onMouseMove(() => addKaboom(mousePos()));

--- a/examples/largeTexture.js
+++ b/examples/largeTexture.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 let cameraPosition = camPos();
 let cameraScale = 1;

--- a/examples/layer.js
+++ b/examples/layer.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 

--- a/examples/level.js
+++ b/examples/level.js
@@ -1,7 +1,7 @@
 // Build levels with addLevel()
 
 // Start game
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/linejoin.js
+++ b/examples/linejoin.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 onDraw(() => {
     // Rectangles

--- a/examples/loader.js
+++ b/examples/loader.js
@@ -1,6 +1,6 @@
 // Customizing the asset loader
 
-kaboom({
+kaplay({
     // Optionally turn off loading screen entirely
     // Unloaded assets simply won't be drawn
     // loadingScreen: false,

--- a/examples/maze.js
+++ b/examples/maze.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     scale: 0.5,
     background: [0, 0, 0],
 });

--- a/examples/mazeRaycastedLight.js
+++ b/examples/mazeRaycastedLight.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     scale: 0.5,
     background: [0, 0, 0],
 });

--- a/examples/movement.js
+++ b/examples/movement.js
@@ -1,7 +1,7 @@
 // Input handling and basic player movement
 
 // Start kaboom
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/multiboom.js
+++ b/examples/multiboom.js
@@ -11,7 +11,7 @@ const positions = [
 ];
 
 for (let i = 0; i < 2; i++) {
-    const k = kaboom({
+    const k = kaplay({
         background: backgrounds[i],
         global: false,
         width: 320,

--- a/examples/multigamepad.js
+++ b/examples/multigamepad.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 setGravity(2400);
 setBackground(0, 0, 0);
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/out.js
+++ b/examples/out.js
@@ -1,6 +1,6 @@
 // detect if obj is out of screen
 
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 

--- a/examples/overlap.js
+++ b/examples/overlap.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 add([
     pos(80, 80),

--- a/examples/particle.js
+++ b/examples/particle.js
@@ -1,6 +1,6 @@
 // Particle spawning
 
-kaboom();
+kaplay();
 
 const sprites = [
     "apple",

--- a/examples/pauseMenu.js
+++ b/examples/pauseMenu.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 loadSound("score", "/examples/sounds/score.mp3");

--- a/examples/platformer.js
+++ b/examples/platformer.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     background: [141, 183, 255],
 });
 

--- a/examples/polygon.js
+++ b/examples/polygon.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 setBackground(0, 0, 0);
 

--- a/examples/polygonuv.js
+++ b/examples/polygonuv.js
@@ -1,7 +1,7 @@
 // Adding game objects to screen
 
 // Start a kaboom game
-kaboom();
+kaplay();
 
 // Load a sprite asset from "sprites/bean.png", with the name "bean"
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/pong.js
+++ b/examples/pong.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     background: [255, 255, 128],
 });
 

--- a/examples/postEffect.js
+++ b/examples/postEffect.js
@@ -1,7 +1,7 @@
 // Build levels with addLevel()
 
 // Start game
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/raycastObject.js
+++ b/examples/raycastObject.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 add([
     pos(80, 80),

--- a/examples/raycastShape.js
+++ b/examples/raycastShape.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 add([
     pos(80, 80),

--- a/examples/rpg.js
+++ b/examples/rpg.js
@@ -1,6 +1,6 @@
 // simple rpg style walk and talk
 
-kaboom({
+kaplay({
     background: [74, 48, 82],
 });
 

--- a/examples/runner.js
+++ b/examples/runner.js
@@ -3,7 +3,7 @@ const JUMP_FORCE = 800;
 const SPEED = 480;
 
 // initialize context
-kaboom();
+kaplay();
 
 setBackground(141, 183, 255);
 

--- a/examples/scenes.js
+++ b/examples/scenes.js
@@ -1,7 +1,7 @@
 // Extend our game with multiple scenes
 
 // Start game
-kaboom();
+kaplay();
 
 // Load assets
 loadSprite("bean", "/sprites/bean.png");

--- a/examples/shader.js
+++ b/examples/shader.js
@@ -1,7 +1,7 @@
 // TODO: shader documentation in doc/
 
 // Custom shader
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 

--- a/examples/shooter.js
+++ b/examples/shooter.js
@@ -1,6 +1,6 @@
 // TODO: document
 
-kaboom({
+kaplay({
     background: [74, 48, 82],
 });
 

--- a/examples/size.js
+++ b/examples/size.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     // without specifying "width" and "height", kaboom will size to the container (document.body by default)
     width: 200,
     height: 100,

--- a/examples/slice9.js
+++ b/examples/slice9.js
@@ -1,6 +1,6 @@
 // 9 slice sprite scaling
 
-kaboom();
+kaplay();
 
 // Load a sprite that's made for 9 slice scaling
 loadSprite("9slice", "/examples/sprites/9slice.png", {

--- a/examples/sprite.js
+++ b/examples/sprite.js
@@ -1,7 +1,7 @@
 // Sprite animation
 
 // Start a kaboom game
-kaboom({
+kaplay({
     // Scale the whole game up
     scale: 4,
     // Set the default font

--- a/examples/spriteatlas.js
+++ b/examples/spriteatlas.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     scale: 4,
     background: [0, 0, 0],
 });

--- a/examples/text.js
+++ b/examples/text.js
@@ -1,4 +1,4 @@
-kaboom({
+kaplay({
     background: [212, 110, 179],
 });
 

--- a/examples/timer.js
+++ b/examples/timer.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 loadSprite("bean", "/sprites/bean.png");
 

--- a/examples/transformShape.js
+++ b/examples/transformShape.js
@@ -1,4 +1,4 @@
-kaboom();
+kaplay();
 
 add([
     pos(80, 80),

--- a/examples/tween.js
+++ b/examples/tween.js
@@ -1,6 +1,6 @@
 // Tweeeeeening!
 
-kaboom({
+kaplay({
     background: [141, 183, 255],
 });
 

--- a/pkgs/matter/examples/basic.js
+++ b/pkgs/matter/examples/basic.js
@@ -1,4 +1,4 @@
-const k = kaboom();
+const k = kaplay();
 const { marea, mbody } = kmatter(k);
 
 const me = k.add([

--- a/pkgs/matter/examples/bird.js
+++ b/pkgs/matter/examples/bird.js
@@ -1,4 +1,4 @@
-const k = kaboom({
+const k = kaplay({
     global: false,
 });
 

--- a/pkgs/matter/examples/drag.js
+++ b/pkgs/matter/examples/drag.js
@@ -1,4 +1,4 @@
-const k = kaboom();
+const k = kaplay();
 const { marea, mbody } = kmatter(k);
 
 const me = k.add([

--- a/pkgs/matter/examples/terrain.js
+++ b/pkgs/matter/examples/terrain.js
@@ -1,4 +1,4 @@
-const k = kaboom();
+const k = kaplay();
 const { marea, mbody } = kmatter(k);
 
 const me = k.add([

--- a/scripts/lib.js
+++ b/scripts/lib.js
@@ -12,10 +12,10 @@ const srcPath = `${srcDir}/kaboom.ts`;
 const fmts = [
     {
         format: "iife",
-        globalName: "startGame",
+        globalName: "kaplay",
         outfile: `${distDir}/kaboom.js`,
         footer: {
-            js: "window.kaboom = startGame.default; window.startGame = startGame.default",
+            js: "window.kaboom = kaplay.default; window.kaplay = kaplay.default",
         },
     },
     { format: "cjs", outfile: `${distDir}/kaboom.cjs` },
@@ -181,7 +181,7 @@ export async function genDTS() {
         throw new Error("KaboomCtx not found, failed to generate global defs.");
     }
 
-    writeFile(`${distDir}/kaboom.d.ts`, dts + "\n\nexport default startGame;");
+    writeFile(`${distDir}/kaboom.d.ts`, dts + "\n\nexport default kaplay;");
     writeFile(`${distDir}/global.d.ts`, globalDts);
     writeFile(`${distDir}/global.js`, "");
 }

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -284,8 +284,8 @@ export const getInternalContext = (kaboom: KaboomCtx): InternalCtx => {
     return kaboom._k;
 };
 
-// only exports one kaboom() which contains all the state
-const startGame = (gopt: KaboomOpt = {}): KaboomCtx => {
+// only exports one kaplay() which contains all the state
+const kaplay = (gopt: KaboomOpt = {}): KaboomCtx => {
     const root = gopt.root ?? document.body;
 
     // if root is not defined (which falls back to <body>) we assume user is using kaboom on a clean page, and modify <body> to better fit a full screen canvas
@@ -5538,4 +5538,4 @@ const startGame = (gopt: KaboomOpt = {}): KaboomCtx => {
     return ctx;
 };
 
-export default startGame;
+export default kaplay;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,10 +4,10 @@
  * @example
  * ```js
  * // Start KAPLAY with default options (will create a fullscreen canvas under <body>)
- * startGame()
+ * kaplay()
  *
  * // Init with some options
- * startGame({
+ * kaplay({
  *     width: 320,
  *     height: 240,
  *     font: "sans-serif",
@@ -15,14 +15,14 @@
  *     background: [ 0, 0, 255, ],
  * })
  *
- * // All kaboom functions are imported to global after calling startGame()
+ * // All kaboom functions are imported to global after calling kaplay()
  * add()
  * onUpdate()
  * onKeyPress()
  * vec2()
  *
  * // If you want to prevent kaboom from importing all functions to global and use a context handle for all kaboom functions
- * const k = startGame({ global: false })
+ * const k = kaplay({ global: false })
  *
  * k.add(...)
  * k.onUpdate(...)
@@ -32,7 +32,7 @@
  *
  * @group Start
  */
-declare function startGame<T extends PluginList<unknown> = [undefined]>(
+declare function kaplay<T extends PluginList<unknown> = [undefined]>(
     options?: KaboomOpt<T>,
 ): T extends [undefined] ? KaboomCtx : KaboomCtx & MergePlugins<T>;
 


### PR DESCRIPTION
Added `kaplay()`

the kaboom example teach how you can still use `kaboom`