### PR TITLE
fix: full screen judgment

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -189,12 +189,6 @@ export default (opt: {
         else if (document.webkitExitFullScreen) document.webkitExitFullScreen();
     }
 
-    function getFullscreenElement(): Element | void {
-        return document.fullscreenElement
-            // @ts-ignore
-            || document.webkitFullscreenElement;
-    }
-
     function setFullscreen(f: boolean = true) {
         if (f) {
             enterFullscreen(state.canvas);
@@ -204,7 +198,9 @@ export default (opt: {
     }
 
     function isFullscreen(): boolean {
-        return Boolean(getFullscreenElement());
+        return document.fullscreenElement === state.canvas
+            // @ts-ignore
+            || document.webkitFullscreenElement === state.canvas;
     }
 
     function quit() {


### PR DESCRIPTION
The `isFullscreen()` function gets the fullscreen DOM object, but doesn't determine if it's the game canvas or not. When the `letterbox` option is set in the game, going fullscreen on the entire web page will result in the game canvas size changing, but the game resolution not updating, so I've changed the `isFullscreen()` function to work around this issue.