### PR TITLE
feat: declaration maps, avoid duplicated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,24 +8,24 @@
   "type": "module",
   "main": "./dist/kaboom.cjs",
   "module": "./dist/kaboom.mjs",
-  "types": "./dist/kaboom.d.ts",
+  "types": "./dist/declaration/types.d.ts",
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/kaboom.d.ts",
+        "types": "./dist/declaration/types.d.ts",
         "default": "./dist/kaboom.mjs"
       },
       "require": {
-        "types": "./dist/kaboom.d.ts",
+        "types": "./dist/declaration/types.d.ts",
         "default": "./dist/kaboom.cjs"
       }
     },
-    "./global": "./dist/global.js"
+    "./global": "./dist/declaration/global.js"
   },
   "typesVersions": {
     "*": {
       "global": [
-        "./dist/global.d.ts"
+        "./dist/declaration/global.d.ts"
       ]
     }
   },
@@ -58,5 +58,8 @@
     "express": "^4.18.3",
     "puppeteer": "^22.4.1",
     "typescript": "^5.4.2"
+  },
+  "dependencies": {
+    "esbuild-plugin-d-ts-path-alias": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,11 +55,9 @@
     "@typescript-eslint/eslint-plugin": "^7.2.0",
     "dprint": "^0.45.1",
     "esbuild": "^0.20.1",
+    "esbuild-plugin-d-ts-path-alias": "^4.2.0",
     "express": "^4.18.3",
     "puppeteer": "^22.4.1",
     "typescript": "^5.4.2"
-  },
-  "dependencies": {
-    "esbuild-plugin-d-ts-path-alias": "^4.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      esbuild-plugin-d-ts-path-alias:
-        specifier: ^4.2.0
-        version: 4.2.0(esbuild@0.20.2)(typescript@5.4.5)
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.2.0
@@ -21,6 +17,9 @@ importers:
       esbuild:
         specifier: ^0.20.1
         version: 0.20.2
+      esbuild-plugin-d-ts-path-alias:
+        specifier: ^4.2.0
+        version: 4.2.0(esbuild@0.20.2)(typescript@5.4.5)
       express:
         specifier: ^4.18.3
         version: 4.19.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      esbuild-plugin-d-ts-path-alias:
+        specifier: ^4.2.0
+        version: 4.2.0(esbuild@0.20.2)(typescript@5.4.5)
     devDependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.2.0
@@ -235,6 +239,7 @@ packages:
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
     engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
 
   '@humanwhocodes/module-importer@1.0.1':
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
@@ -242,6 +247,7 @@ packages:
 
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -580,6 +586,13 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  esbuild-plugin-d-ts-path-alias@4.2.0:
+    resolution: {integrity: sha512-8yUk1kWGpH/NJKxVLkZrdBsmQ/k7SsffaH9AJuDLGEMF4lTqCWba92QmmNCFAxhQNuVLWTUYoUm/8vETEjtQJA==}
+    engines: {node: '>=16.10.0'}
+    peerDependencies:
+      esbuild: ^0.17.0 || ^0.18.0
+      typescript: '>=5.0'
 
   esbuild@0.20.2:
     resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
@@ -1250,6 +1263,11 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
+  typescript-transform-paths@3.4.6:
+    resolution: {integrity: sha512-qdgpCk9oRHkIBhznxaHAapCFapJt5e4FbFik7Y4qdqtp6VyC3smAIPoDEIkjZ2eiF7x5+QxUPYNwJAtw0thsTw==}
+    peerDependencies:
+      typescript: '>=3.6.5'
+
   typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
     engines: {node: '>=14.17'}
@@ -1853,6 +1871,12 @@ snapshots:
       get-intrinsic: 1.2.4
 
   es-errors@1.3.0: {}
+
+  esbuild-plugin-d-ts-path-alias@4.2.0(esbuild@0.20.2)(typescript@5.4.5):
+    dependencies:
+      esbuild: 0.20.2
+      typescript: 5.4.5
+      typescript-transform-paths: 3.4.6(typescript@5.4.5)
 
   esbuild@0.20.2:
     optionalDependencies:
@@ -2629,6 +2653,11 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
+
+  typescript-transform-paths@3.4.6(typescript@5.4.5):
+    dependencies:
+      minimatch: 3.1.2
+      typescript: 5.4.5
 
   typescript@5.4.5: {}
 

--- a/src/assets.ts
+++ b/src/assets.ts
@@ -1,5 +1,8 @@
 import { Event } from "./utils";
 
+/**
+ * An asset is a resource that is loaded asynchronously.
+ */
 export class Asset<D> {
     loaded: boolean = false;
     data: D | null = null;

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -1,0 +1,38 @@
+import {
+    DEF_FONT_FILTER,
+    DEF_TEXT_CACHE_SIZE,
+    MAX_TEXT_CACHE_SIZE,
+} from "./constants";
+import { rgb } from "./math";
+import type { LoadFontOpt, Outline, TexFilter } from "./types";
+
+export class FontData {
+    fontface: FontFace;
+    filter: TexFilter = DEF_FONT_FILTER;
+    outline: Outline | null = null;
+    size: number = DEF_TEXT_CACHE_SIZE;
+    constructor(face: FontFace, opt: LoadFontOpt = {}) {
+        this.fontface = face;
+        this.filter = opt.filter ?? DEF_FONT_FILTER;
+        this.size = opt.size ?? DEF_TEXT_CACHE_SIZE;
+        if (this.size > MAX_TEXT_CACHE_SIZE) {
+            throw new Error(`Max font size: ${MAX_TEXT_CACHE_SIZE}`);
+        }
+        if (opt.outline) {
+            this.outline = {
+                width: 1,
+                color: rgb(0, 0, 0),
+            };
+            if (typeof opt.outline === "number") {
+                this.outline.width = opt.outline;
+            } else if (typeof opt.outline === "object") {
+                if (opt.outline.width) {
+                    this.outline.width = opt.outline.width;
+                }
+                if (opt.outline.color) {
+                    this.outline.color = opt.outline.color;
+                }
+            }
+        }
+    }
+}

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -120,6 +120,8 @@ import {
     uid,
 } from "./utils";
 
+import { FontData } from "./fonts";
+
 import type {
     Anchor,
     AreaComp,
@@ -738,37 +740,6 @@ const kaplay = (gopt: KaboomOpt = {}): KaboomCtx => {
         return assets.custom.add(name, fetchJSON(url));
     }
 
-    class FontData {
-        fontface: FontFace;
-        filter: TexFilter = DEF_FONT_FILTER;
-        outline: Outline | null = null;
-        size: number = DEF_TEXT_CACHE_SIZE;
-        constructor(face: FontFace, opt: LoadFontOpt = {}) {
-            this.fontface = face;
-            this.filter = opt.filter ?? DEF_FONT_FILTER;
-            this.size = opt.size ?? DEF_TEXT_CACHE_SIZE;
-            if (this.size > MAX_TEXT_CACHE_SIZE) {
-                throw new Error(`Max font size: ${MAX_TEXT_CACHE_SIZE}`);
-            }
-            if (opt.outline) {
-                this.outline = {
-                    width: 1,
-                    color: rgb(0, 0, 0),
-                };
-                if (typeof opt.outline === "number") {
-                    this.outline.width = opt.outline;
-                } else if (typeof opt.outline === "object") {
-                    if (opt.outline.width) {
-                        this.outline.width = opt.outline.width;
-                    }
-                    if (opt.outline.color) {
-                        this.outline.color = opt.outline.color;
-                    }
-                }
-            }
-        }
-    }
-
     // TODO: pass in null src to store opt for default fonts like "monospace"
     function loadFont(
         name: string,
@@ -1167,8 +1138,7 @@ const kaplay = (gopt: KaboomOpt = {}): KaboomCtx => {
         } else if (src instanceof Asset) {
             return src.data ? src.data : src;
         }
-        // TODO: check type
-        // @ts-ignore
+
         return src;
     }
 
@@ -1204,8 +1174,7 @@ const kaplay = (gopt: KaboomOpt = {}): KaboomCtx => {
         } else if (src instanceof Asset) {
             return src.data ? src.data : src;
         }
-        // TODO: check type
-        // @ts-ignore
+
         return src;
     }
 

--- a/src/math.ts
+++ b/src/math.ts
@@ -56,83 +56,169 @@ export function mapc(
     return clamp(map(v, l1, h1, l2, h2), l2, h2);
 }
 
+/**
+ * A 2D vector.
+ *
+ * @group Math
+ */
 export class Vec2 {
+    /** The x coordinate */
     x: number = 0;
+    /** The y coordinate */
     y: number = 0;
+
     constructor(x: number = 0, y: number = x) {
         this.x = x;
         this.y = y;
     }
+
+    /** Create a new Vec2 from an angle in degrees */
     static fromAngle(deg: number) {
         const angle = deg2rad(deg);
         return new Vec2(Math.cos(angle), Math.sin(angle));
     }
+
     static LEFT = new Vec2(-1, 0);
     static RIGHT = new Vec2(1, 0);
     static UP = new Vec2(0, -1);
     static DOWN = new Vec2(0, 1);
+
+    /** Clone the vector */
     clone(): Vec2 {
         return new Vec2(this.x, this.y);
     }
+
+    /** Returns the addition with another vector. */
     add(...args: Vec2Args): Vec2 {
         const p2 = vec2(...args);
         return new Vec2(this.x + p2.x, this.y + p2.y);
     }
+
+    /** Returns the subtraction with another vector. */
     sub(...args: Vec2Args): Vec2 {
         const p2 = vec2(...args);
         return new Vec2(this.x - p2.x, this.y - p2.y);
     }
+
+    /** Scale by another vector. or a single number */
     scale(...args: Vec2Args): Vec2 {
         const s = vec2(...args);
         return new Vec2(this.x * s.x, this.y * s.y);
     }
+
+    /** Get distance between another vector */
     dist(...args: Vec2Args): number {
         const p2 = vec2(...args);
         return this.sub(p2).len();
     }
+
+    /** Get squared distance between another vector */
     sdist(...args: Vec2Args): number {
         const p2 = vec2(...args);
         return this.sub(p2).slen();
     }
+
     len(): number {
         return Math.sqrt(this.dot(this));
     }
+
+    /**
+     * Get squared length of the vector
+     *
+     * @since v3000.0
+     */
     slen(): number {
         return this.dot(this);
     }
+
+    /**
+     * Get the unit vector (length of 1).
+     */
     unit(): Vec2 {
         const len = this.len();
         return len === 0 ? new Vec2(0) : this.scale(1 / len);
     }
+
+    /**
+     * Get the perpendicular vector.
+     */
     normal(): Vec2 {
         return new Vec2(this.y, -this.x);
     }
+
+    /**
+     * Get the reflection of a vector with a normal.
+     *
+     * @since v3000.0
+     */
     reflect(normal: Vec2) {
         return this.sub(normal.scale(2 * this.dot(normal)));
     }
+
+    /**
+     * Get the projection of a vector onto another vector.
+     *
+     * @since v3000.0
+     */
     project(on: Vec2) {
         return on.scale(on.dot(this) / on.len());
     }
+
+    /**
+     * Get the rejection of a vector onto another vector.
+     *
+     * @since v3000.0
+     */
     reject(on: Vec2) {
         return this.sub(this.project(on));
     }
+
+    /**
+     * Get the dot product with another vector.
+     */
     dot(p2: Vec2): number {
         return this.x * p2.x + this.y * p2.y;
     }
+
+    /**
+     * Get the cross product with another vector.
+     *
+     * @since v3000.0
+     */
     cross(p2: Vec2): number {
         return this.x * p2.y - this.y * p2.x;
     }
+
+    /**
+     * Get the angle of the vector in degrees.
+     */
     angle(...args: Vec2Args): number {
         const p2 = vec2(...args);
         return rad2deg(Math.atan2(this.y - p2.y, this.x - p2.x));
     }
+
+    /**
+     * Get the angle between this vector and another vector.
+     *
+     * @since v3000.0
+     */
     angleBetween(...args: Vec2Args): number {
         const p2 = vec2(...args);
         return rad2deg(Math.atan2(this.cross(p2), this.dot(p2)));
     }
+
+    /**
+     * Linear interpolate to a destination vector (for positions).
+     */
     lerp(dest: Vec2, t: number): Vec2 {
         return new Vec2(lerp(this.x, dest.x, t), lerp(this.y, dest.y, t));
     }
+
+    /**
+     * Spherical linear interpolate to a destination vector (for rotations).
+     *
+     * @since v3000.0
+     */
     slerp(dest: Vec2, t: number): Vec2 {
         const cos = this.dot(dest);
         const sin = this.cross(dest);
@@ -142,21 +228,40 @@ export class Vec2 {
             .add(dest.scale(Math.sin(t * angle)))
             .scale(1 / sin);
     }
+
+    /**
+     * If the vector (x, y) is zero.
+     *
+     * @since v3000.0
+     */
     isZero(): boolean {
         return this.x === 0 && this.y === 0;
     }
+
+    /**
+     * To n precision floating point.
+     */
     toFixed(n: number): Vec2 {
         return new Vec2(Number(this.x.toFixed(n)), Number(this.y.toFixed(n)));
     }
+
+    /**
+     * Multiply by a Mat4.
+     *
+     * @since v3000.0
+     */
     transform(m: Mat4): Vec2 {
         return m.multVec2(this);
     }
+
     eq(other: Vec2): boolean {
         return this.x === other.x && this.y === other.y;
     }
+
     bbox(): Rect {
         return new Rect(this, 0, 0);
     }
+
     toString(): string {
         return `vec2(${this.x.toFixed(2)}, ${this.y.toFixed(2)})`;
     }
@@ -982,7 +1087,7 @@ export class Mat4 {
             const r = Math.sqrt(this.m[0] * this.m[0] + this.m[1] * this.m[1]);
             return new Vec2(
                 Math.atan(this.m[0] * this.m[4] + this.m[1] * this.m[5])
-                / (r * r),
+                    / (r * r),
                 0,
             );
         } else if (this.m[4] != 0 || this.m[5] != 0) {
@@ -990,7 +1095,7 @@ export class Mat4 {
             return new Vec2(
                 0,
                 Math.atan(this.m[0] * this.m[4] + this.m[1] * this.m[5])
-                / (s * s),
+                    / (s * s),
             );
         } else {
             return new Vec2(0, 0);
@@ -1405,7 +1510,7 @@ export function testPolygonPoint(poly: Polygon, pt: Point): boolean {
             ((p[i].y > pt.y) != (p[j].y > pt.y))
             && (pt.x
                 < (p[j].x - p[i].x) * (pt.y - p[i].y) / (p[j].y - p[i].y)
-                + p[i].x)
+                    + p[i].x)
         ) {
             c = !c;
         }
@@ -1423,7 +1528,7 @@ export function testEllipsePoint(ellipse: Ellipse, pt: Point): boolean {
     const vx = pt.x * c + pt.y * s;
     const vy = -pt.x * s + pt.y * c;
     return vx * vx / (ellipse.radiusX * ellipse.radiusX)
-        + vy * vy / (ellipse.radiusY * ellipse.radiusY) < 1;
+            + vy * vy / (ellipse.radiusY * ellipse.radiusY) < 1;
 }
 
 export function testEllipseCircle(ellipse: Ellipse, circle: Circle): boolean {
@@ -2227,7 +2332,7 @@ export class Ellipse {
         const vx = point.x * c + point.y * s;
         const vy = -point.x * s + point.y * c;
         return vx * vx / (this.radiusX * this.radiusX)
-            + vy * vy / (this.radiusY * this.radiusY) < 1;
+                + vy * vy / (this.radiusY * this.radiusY) < 1;
     }
     raycast(origin: Vec2, direction: Vec2): RaycastResult {
         return raycastEllipse(origin, direction, this);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,10 @@
+import type { Asset } from "@/assets";
+import type { FontData } from "@/fonts";
+import type { Event, EventController, EventHandler } from "@/utils";
+import type { Vec2 } from "./math";
+
+export type { Asset, Event, EventController, EventHandler, FontData, Vec2 };
+
 /**
  * Initialize KAPLAY context. The starting point of all KAPLAY games.
  *
@@ -3202,7 +3209,6 @@ export interface KaboomCtx {
 
 export type Tag = string;
 
-// TODO: understand this
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends
     ((k: infer I) => void) ? I : never;
 type Defined<T> = T extends any
@@ -3939,21 +3945,6 @@ export type SpriteAtlasEntry = LoadSpriteOpt & {
     height: number;
 };
 
-// TODO: use PromiseLike or extend Promise?
-export declare class Asset<D> {
-    loaded: boolean;
-    data: D | null;
-    error: Error | null;
-    constructor(loader: Promise<D>);
-    static loaded<D>(data: D): Asset<D>;
-    onLoad(action: (data: D) => void): Asset<D>;
-    onError(action: (err: Error) => void): Asset<D>;
-    onFinish(action: () => void): Asset<D>;
-    then(action: (data: D) => void): Asset<D>;
-    catch(action: (err: Error) => void): Asset<D>;
-    finally(action: () => void): Asset<D>;
-}
-
 export type LoadSpriteSrc = string | ImageSource;
 
 export type AsepriteData = {
@@ -4019,12 +4010,6 @@ export interface LoadBitmapFontOpt {
     chars?: string;
     filter?: TexFilter;
     outline?: number;
-}
-
-export declare class FontData {
-    fontface: FontFace;
-    filter: TexFilter;
-    outline: Outline | null;
 }
 
 export type BitmapFontData = GfxFont;
@@ -4815,133 +4800,6 @@ export type Vec2Args =
     | [Vec2]
     | [number | Vec2]
     | [];
-
-/**
- * A 2D vector.
- *
- * @group Math
- */
-export declare class Vec2 {
-    x: number;
-    y: number;
-    static LEFT: Vec2;
-    static RIGHT: Vec2;
-    static UP: Vec2;
-    static DOWN: Vec2;
-    static fromAngle(deg: number): Vec2;
-    constructor(x: number, y: number);
-    constructor(xy: number);
-    constructor();
-    clone(): Vec2;
-    /**
-     * Returns the addition with another vector.
-     */
-    add(p: Vec2): Vec2;
-    add(x: number, y: number): Vec2;
-    /**
-     * Returns the subtraction with another vector.
-     */
-    sub(p: Vec2): Vec2;
-    sub(x: number, y: number): Vec2;
-    /**
-     * Scale by another vector, or a single number.
-     */
-    scale(p: Vec2): Vec2;
-    scale(s: number): Vec2;
-    scale(sx: number, sy: number): Vec2;
-    /**
-     * Get the dot product with another vector.
-     */
-    dot(p: Vec2): number;
-    /**
-     * Get the cross product with another vector.
-     *
-     * @since v3000.0
-     */
-    cross(p2: Vec2): number;
-    /**
-     * Get distance between another vector.
-     */
-    dist(p: Vec2): number;
-    /**
-     * Get squared distance between another vector.
-     *
-     * @since v3000.0
-     */
-    sdist(p: Vec2): number;
-    len(): number;
-    /**
-     * Get squared length of a vector.
-     *
-     * @since v3000.0
-     */
-    slen(): number;
-    /**
-     * Get the unit vector (length of 1).
-     */
-    unit(): Vec2;
-    /**
-     * Get the perpendicular vector.
-     */
-    normal(): Vec2;
-    /**
-     * Get the reflection of a vector with a normal.
-     *
-     * @since v3000.0
-     */
-    reflect(normal: Vec2): Vec2;
-    /**
-     * Get the projection of a vector onto another vector.
-     *
-     * @since v3000.0
-     */
-    project(on: Vec2): Vec2;
-    /**
-     * Get the rejection of a vector onto another vector.
-     *
-     * @since v3000.0
-     */
-    reject(on: Vec2): Vec2;
-    /**
-     * Get the angle of the vector from p towards this.
-     */
-    angle(p: Vec2): number;
-    /**
-     * Get the angle between this vector and another vector.
-     *
-     * @since v3000.0
-     */
-    angleBetween(...args: any): number;
-    /**
-     * Linear interpolate to a destination vector (for positions).
-     */
-    lerp(p: Vec2, t: number): Vec2;
-    /**
-     * Spherical linear interpolate to a destination vector (for rotations).
-     *
-     * @since v3000.0
-     */
-    slerp(p: Vec2, t: number): Vec2;
-    /**
-     * If both x and y is 0.
-     *
-     * @since v3000.0
-     */
-    isZero(): boolean;
-    /**
-     * To n precision floating point.
-     */
-    toFixed(n: number): Vec2;
-    /**
-     * Multiply by a Mat4.
-     *
-     * @since v3000.0
-     */
-    transform(n: Mat4): Vec2;
-    bbox(): Rect;
-    eq(p: Vec2): boolean;
-    toString(): string;
-}
 
 /**
  * @group Math
@@ -6799,38 +6657,6 @@ export type TweenController = TimerController & {
     finish(): void;
 };
 
-/**
- * A controller for all events in KAPLAY.
- *
- * @example
- * ```js
- * // Create a new event
- * const logHi = onUpdate(() => {
- *    debug.log("hi");
- * });
- *
- * // Pause the event
- * logHi.paused = true;
- *
- * // Cancel the event
- * logHi.cancel();
- *
- * ```
- * @group Events
- */
-export declare class EventController {
-    /**
-     * If the event handler is paused.
-     */
-    paused: boolean;
-    /**
-     * Cancel the event handler.
-     */
-    readonly cancel: () => void;
-    constructor(cancel: () => void);
-    static join(events: EventController[]): EventController;
-}
-
 export interface SpriteCurAnim {
     name: string;
     timer: number;
@@ -6840,31 +6666,4 @@ export interface SpriteCurAnim {
     onEnd: () => void;
 }
 
-// TODO: global name conflict, renamed to KEvent?
-export declare class Event<Args extends any[] = any[]> {
-    add(action: (...args: Args) => void): EventController;
-    addOnce(action: (...args: any) => void): EventController;
-    next(): Promise<Args>;
-    trigger(...args: Args): void;
-    numListeners(): number;
-    clear(): void;
-}
-
-export declare class EventHandler<EventMap extends Record<string, any[]>> {
-    on<Name extends keyof EventMap>(
-        name: Name,
-        action: (...args: EventMap[Name]) => void,
-    ): EventController;
-    onOnce<Name extends keyof EventMap>(
-        name: Name,
-        action: (...args: EventMap[Name]) => void,
-    ): EventController;
-    next<Name extends keyof EventMap>(name: Name): Promise<unknown>;
-    trigger<Name extends keyof EventMap>(
-        name: Name,
-        ...args: EventMap[Name]
-    ): void;
-    remove<Name extends keyof EventMap>(name: Name): void;
-    clear(): void;
-    numListeners<Name extends keyof EventMap>(name: Name): number;
-}
+export default kaplay;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,9 +12,31 @@ export class Registry<T> extends Map<number, T> {
     }
 }
 
+/**
+ * A controller for all events in KAPLAY.
+ *
+ * @example
+ * ```js
+ * // Create a new event
+ * const logHi = onUpdate(() => {
+ *    debug.log("hi");
+ * });
+ *
+ * // Pause the event
+ * logHi.paused = true;
+ *
+ * // Cancel the event
+ * logHi.cancel();
+ *
+ * ```
+ * @group Events
+ */
 export class EventController {
+    /** If the event is paused */
     paused: boolean = false;
+    /** Cancel the event */
     readonly cancel: () => void;
+
     constructor(cancel: () => void) {
         this.cancel = cancel;
     }
@@ -580,5 +602,7 @@ export function substring(string: string, start?: number, width?: number) {
 }
 
 export function isClass(obj: any): boolean {
-  return obj?.prototype && Object.getOwnPropertyDescriptor(obj.prototype, 'constructor') !== undefined;
+    return obj?.prototype
+        && Object.getOwnPropertyDescriptor(obj.prototype, "constructor")
+            !== undefined;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
     "esModuleInterop": true,
     "target": "ESNext",
     "moduleResolution": "Node",
     "noImplicitThis": false,
     "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
This PR address to fix issues related to the types duplication between modules, for example `Vec2` between math.ts and types.ts, etc. To do this, an esbuild plugin is used, it generates the declaration files for every module.

The declaration maps adds the possibility of go direct to the source code with clicked in a Symbol, for example `Vec2`

close #126
close #97 

**Note:** Not all replacements to duplicated types are addressed, only `Vec2`, `Asset`, `FontData` and related to events (`Event`, `EventControllers`), they should be addressed, but I don't want much merge conflicts so others will be addressed in others PR. Also the idea is move CompOpts to their own component file 

It also separates `FontData` from `kaboom.ts` to new module `fonts.ts` (may be temp)