### PR TITLE
refactor: move component types/opt from types.ts to their modules

### DIFF
--- a/src/components/draw/circle.ts
+++ b/src/components/draw/circle.ts
@@ -1,30 +1,42 @@
 import { getKaboomContext } from "../../kaboom";
 import { Rect, Vec2 } from "../../math";
-import type {
-    AnchorComp,
-    CircleComp,
-    CircleCompOpt,
-    GameObj,
-    KaboomCtx,
-} from "../../types";
+import type { Comp, GameObj } from "../../types";
+import type { AnchorComp } from "../transform/anchor";
+import type { outline } from "./outline";
 
-function getRenderProps(obj: GameObj<any>) {
-    return {
-        color: obj.color,
-        opacity: obj.opacity,
-        anchor: obj.anchor,
-        outline: obj.outline,
-        shader: obj.shader,
-        uniform: obj.uniform,
-    };
+/**
+ * The {@link circle `circle()`} component.
+ *
+ * @group Components
+ */
+export interface CircleComp extends Comp {
+    draw: Comp["draw"];
+    /** Radius of circle. */
+    radius: number;
+    /**
+     * Render area of the circle.
+     *
+     * @since v3000.0
+     */
+    renderArea(): Rect;
 }
 
-export function circle(
-    this: KaboomCtx,
-    radius: number,
-    opt: CircleCompOpt = {},
-): CircleComp {
+/**
+ * Options for the {@link circle `circle()``} component.
+ *
+ * @group Components
+ */
+export interface CircleCompOpt {
+    /**
+     * If fill the circle (useful if you only want to render outline with
+     * {@link outline `outline()`} component).
+     */
+    fill?: boolean;
+}
+
+export function circle(radius: number, opt: CircleCompOpt = {}): CircleComp {
     const k = getKaboomContext(this);
+    const { getRenderProps } = k._k;
 
     return {
         id: "circle",

--- a/src/components/draw/color.ts
+++ b/src/components/draw/color.ts
@@ -1,0 +1,21 @@
+import { type Color, rgb } from "../../math";
+import type { Comp } from "../../types";
+
+/**
+ * The {@link color `color()`} component.
+ *
+ * @group Components
+ */
+export interface ColorComp extends Comp {
+    color: Color;
+}
+
+export function color(...args): ColorComp {
+    return {
+        id: "color",
+        color: rgb(...args),
+        inspect() {
+            return this.color.toString();
+        },
+    };
+}

--- a/src/components/draw/fadeIn.ts
+++ b/src/components/draw/fadeIn.ts
@@ -1,5 +1,6 @@
 import { getKaboomContext } from "../../kaboom";
-import type { Comp, GameObj, OpacityComp } from "../../types";
+import type { Comp, GameObj } from "../../types";
+import type { OpacityComp } from "./opacity";
 
 export function fadeIn(time: number = 1): Comp {
     const k = getKaboomContext(this);

--- a/src/components/draw/mask.ts
+++ b/src/components/draw/mask.ts
@@ -1,4 +1,13 @@
-import type { Mask, MaskComp } from "../../types";
+import type { Comp, Mask } from "../../types";
+
+/**
+ * The {@link mask `mask()`} component.
+ *
+ * @group Components
+ */
+export interface MaskComp extends Comp {
+    mask: Mask;
+}
 
 export function mask(m: Mask = "intersect"): MaskComp {
     return {

--- a/src/components/draw/opacity.ts
+++ b/src/components/draw/opacity.ts
@@ -1,15 +1,29 @@
-import { getInternalContext, getKaboomContext } from "../../kaboom";
-import type { OpacityComp, TweenController } from "../../types";
+import { getKaboomContext } from "../../kaboom";
+import type { Comp, EaseFunc, TweenController } from "../../types";
+
+/**
+ * The {@link opacity `opacity()`} component.
+ *
+ * @group Components
+ */
+export interface OpacityComp extends Comp {
+    /** Opacity of the current object. */
+    opacity: number;
+    /** Fade in at the start. */
+    fadeIn(time?: number, easeFunc?: EaseFunc): TweenController;
+    /** Fade out at the start. */
+    fadeOut(time?: number, easeFunc?: EaseFunc): TweenController;
+}
 
 export function opacity(a: number): OpacityComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
+    const { toFixed } = k._k;
 
     return {
         id: "opacity",
         opacity: a ?? 1,
         inspect() {
-            return `${internal.toFixed(this.opacity, 1)}`;
+            return `${toFixed(this.opacity, 1)}`;
         },
         fadeIn(time = 1, easeFunc = k.easings.linear): TweenController {
             return k.tween(

--- a/src/components/draw/outline.ts
+++ b/src/components/draw/outline.ts
@@ -1,5 +1,14 @@
 import { Color, rgb } from "../../math";
-import type { LineCap, LineJoin, OutlineComp } from "../../types";
+import type { Comp, LineCap, LineJoin, Outline } from "../../types";
+
+/**
+ * The {@link outline `outline()`} component.
+ *
+ * @group Components
+ */
+export interface OutlineComp extends Comp {
+    outline: Outline;
+}
 
 export function outline(
     width: number = 1,

--- a/src/components/draw/polygon.ts
+++ b/src/components/draw/polygon.ts
@@ -1,10 +1,53 @@
-import { getInternalContext, getKaboomContext } from "../../kaboom";
-import { Polygon } from "../../math";
-import type { GameObj, PolygonComp, PolygonCompOpt, Vec2 } from "../../types";
+import type { Texture } from "../../gfx";
+import { getKaboomContext } from "../../kaboom";
+import { type Color, Polygon } from "../../math";
+import type { Comp, DrawPolygonOpt, GameObj, Vec2 } from "../../types";
+
+/**
+ * The {@link polygon `polygon()`} component.
+ *
+ * @since v3001.0
+ * @group Components
+ */
+export interface PolygonComp extends Comp {
+    draw: Comp["draw"];
+    /**
+     * Points in the polygon.
+     */
+    pts: Vec2[];
+    /**
+     * The radius of each corner.
+     */
+    radius?: number | number[];
+    /**
+     * The color of each vertex.
+     */
+    colors?: Color[];
+    /**
+     * The uv of each vertex.
+     *
+     * @since v3001.0
+     */
+    uv?: Vec2[];
+    /**
+     * The texture used when uv coordinates are present.
+     *
+     * @since v3001.0
+     */
+    tex?: Texture;
+    renderArea(): Polygon;
+}
+
+/**
+ * Options for the {@link polygon `polygon()`} component.
+ *
+ * @group Components
+ */
+export type PolygonCompOpt = Omit<DrawPolygonOpt, "pts">;
 
 export function polygon(pts: Vec2[], opt: PolygonCompOpt = {}): PolygonComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
+    const { getRenderProps } = k._k;
 
     if (pts.length < 3) {
         throw new Error(
@@ -19,7 +62,7 @@ export function polygon(pts: Vec2[], opt: PolygonCompOpt = {}): PolygonComp {
         tex: opt.tex,
         radius: opt.radius,
         draw(this: GameObj<PolygonComp>) {
-            k.drawPolygon(Object.assign(internal.getRenderProps(this), {
+            k.drawPolygon(Object.assign(getRenderProps(this), {
                 pts: this.pts,
                 colors: this.colors,
                 uv: this.uv,

--- a/src/components/draw/raycast.ts
+++ b/src/components/draw/raycast.ts
@@ -2,6 +2,7 @@ import { getKaboomContext } from "../../kaboom";
 import type { Vec2 } from "../../math";
 import type { RaycastResult } from "../../types";
 
+// this is not a component lol
 export function raycast(origin: Vec2, direction: Vec2, exclude?: string[]) {
     const k = getKaboomContext(this);
     let minHit: RaycastResult;

--- a/src/components/draw/rect.ts
+++ b/src/components/draw/rect.ts
@@ -1,10 +1,51 @@
-import { getInternalContext, getKaboomContext } from "../../kaboom";
+import { getKaboomContext } from "../../kaboom";
 import { Rect, vec2 } from "../../math";
-import type { GameObj, RectComp, RectCompOpt } from "../../types";
+import type { Comp, GameObj } from "../../types";
+
+/**
+ * The {@link rect `rect()`} component.
+ *
+ * @group Components
+ */
+export interface RectComp extends Comp {
+    draw: Comp["draw"];
+    /**
+     * Width of rectangle.
+     */
+    width: number;
+    /**
+     * Height of rectangle.
+     */
+    height: number;
+    /**
+     * The radius of each corner.
+     */
+    radius?: number;
+    /**
+     * @since v3000.0
+     */
+    renderArea(): Rect;
+}
+
+/**
+ * Options for the {@link rect `rect()`} component.
+ *
+ * @group Components
+ */
+export interface RectCompOpt {
+    /**
+     * Radius of the rectangle corners.
+     */
+    radius?: number;
+    /**
+     * If fill the rectangle (useful if you only want to render outline with outline() component).
+     */
+    fill?: boolean;
+}
 
 export function rect(w: number, h: number, opt: RectCompOpt = {}): RectComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
+    const { getRenderProps } = k._k;
 
     return {
         id: "rect",
@@ -12,7 +53,7 @@ export function rect(w: number, h: number, opt: RectCompOpt = {}): RectComp {
         height: h,
         radius: opt.radius || 0,
         draw(this: GameObj<RectComp>) {
-            k.drawRect(Object.assign(internal.getRenderProps(this), {
+            k.drawRect(Object.assign(getRenderProps(this), {
                 width: this.width,
                 height: this.height,
                 radius: this.radius,

--- a/src/components/draw/shader.ts
+++ b/src/components/draw/shader.ts
@@ -1,4 +1,14 @@
-import type { ShaderComp, Uniform } from "../../types";
+import type { Comp, Uniform } from "../../types";
+
+/**
+ * The {@link shader `shader()`} component.
+ *
+ * @group Components
+ */
+export interface ShaderComp extends Comp {
+    uniform: Uniform;
+    shader: string;
+}
 
 export function shader(
     id: string,

--- a/src/components/draw/text.ts
+++ b/src/components/draw/text.ts
@@ -1,14 +1,134 @@
 import { DEF_TEXT_SIZE } from "../../constants";
-import { getInternalContext, getKaboomContext } from "../../kaboom";
+import { getKaboomContext } from "../../kaboom";
 import { Rect, vec2 } from "../../math";
-import type { GameObj, TextComp, TextCompOpt } from "../../types";
+import type {
+    BitmapFontData,
+    CharTransform,
+    CharTransformFunc,
+    Comp,
+    GameObj,
+    TextAlign,
+} from "../../types";
+
+/**
+ * The {@link text `text()`} component.
+ *
+ * @group Components
+ */
+export interface TextComp extends Comp {
+    draw: Comp["draw"];
+    /**
+     * The text to render.
+     */
+    text: string;
+    /**
+     * The text size.
+     */
+    textSize: number;
+    /**
+     * The font to use.
+     */
+    font: string | BitmapFontData;
+    /**
+     * Width of text.
+     */
+    width: number;
+    /**
+     * Height of text.
+     */
+    height: number;
+    /**
+     * Text alignment ("left", "center" or "right", default "left").
+     *
+     * @since v3000.0
+     */
+    align: TextAlign;
+    /**
+     * The gap between each line.
+     *
+     * @since v2000.2
+     */
+    lineSpacing: number;
+    /**
+     * The gap between each character.
+     *
+     * @since v2000.2
+     */
+    letterSpacing: number;
+    /**
+     * Transform the pos, scale, rotation or color for each character based on the index or char.
+     *
+     * @since v2000.1
+     */
+    textTransform: CharTransform | CharTransformFunc;
+    /**
+     * Stylesheet for styled chunks, in the syntax of "this is a [style]text[/style] word".
+     *
+     * @since v2000.2
+     */
+    textStyles: Record<string, CharTransform | CharTransformFunc>;
+    /**
+     * @since v3000.0
+     */
+    renderArea(): Rect;
+}
+
+/**
+ * Options for the {@link text `text()`} component.
+ *
+ * @group Components
+ */
+export interface TextCompOpt {
+    /**
+     * Height of text.
+     */
+    size?: number;
+    /**
+     * The font to use.
+     */
+    font?: string | BitmapFontData;
+    /**
+     * Wrap text to a certain width.
+     */
+    width?: number;
+    /**
+     * Text alignment ("left", "center" or "right", default "left").
+     *
+     * @since v3000.0
+     */
+    align?: TextAlign;
+    /**
+     * The gap between each line.
+     *
+     * @since v2000.2
+     */
+    lineSpacing?: number;
+    /**
+     * The gap between each character.
+     *
+     * @since v2000.2
+     */
+    letterSpacing?: number;
+    /**
+     * Transform the pos, scale, rotation or color for each character based on the index or char.
+     *
+     * @since v2000.1
+     */
+    transform?: CharTransform | CharTransformFunc;
+    /**
+     * Stylesheet for styled chunks, in the syntax of "this is a [style]text[/style] word".
+     *
+     * @since v2000.2
+     */
+    styles?: Record<string, CharTransform | CharTransformFunc>;
+}
 
 export function text(t: string, opt: TextCompOpt = {}): TextComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
+    const { getRenderProps } = k._k;
 
     function update(obj: GameObj<TextComp | any>) {
-        const ftext = k.formatText(Object.assign(internal.getRenderProps(obj), {
+        const ftext = k.formatText(Object.assign(getRenderProps(obj), {
             text: obj.text + "",
             size: obj.textSize,
             font: obj.font,

--- a/src/components/draw/uvquad.ts
+++ b/src/components/draw/uvquad.ts
@@ -1,17 +1,37 @@
-import { getInternalContext, getKaboomContext } from "../../kaboom";
+import { getKaboomContext } from "../../kaboom";
 import { Rect, vec2 } from "../../math";
-import type { GameObj, UVQuadComp } from "../../types";
+import type { Comp, GameObj } from "../../types";
 
+/**
+ * The {@link uvquad `uvquad()`} component.
+ *
+ * @group Components
+ */
+export interface UVQuadComp extends Comp {
+    draw: Comp["draw"];
+    /**
+     * Width of rect.
+     */
+    width: number;
+    /**
+     * Height of height.
+     */
+    height: number;
+    /**
+     * @since v3000.0
+     */
+    renderArea(): Rect;
+}
 export function uvquad(w: number, h: number): UVQuadComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
+    const { getRenderProps } = k._k;
 
     return {
         id: "rect",
         width: w,
         height: h,
         draw(this: GameObj<UVQuadComp>) {
-            k.drawUVQuad(Object.assign(internal.getRenderProps(this), {
+            k.drawUVQuad(Object.assign(getRenderProps(this), {
                 width: this.width,
                 height: this.height,
             }));

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./draw/circle";
+export * from "./draw/color";
 export * from "./draw/drawon";
 export * from "./draw/fadeIn";
 export * from "./draw/mask";

--- a/src/components/level/agent.ts
+++ b/src/components/level/agent.ts
@@ -1,12 +1,39 @@
 import type { Vec2 } from "../../math";
-import type {
-    AgentComp,
-    AgentCompOpt,
-    GameObj,
-    PosComp,
-    TileComp,
-} from "../../types";
+import type { Comp, GameObj, PosComp } from "../../types";
 import type { EventController } from "../../utils";
+import type { TileComp } from "./tile";
+
+/**
+ * The {@link agent `agent()`} component.
+ *
+ * @group Components
+ */
+export interface AgentComp extends Comp {
+    agentSpeed: number;
+    allowDiagonals: boolean;
+    getDistanceToTarget(): number;
+    getNextLocation(): Vec2 | null;
+    getPath(): Vec2[] | null;
+    getTarget(): Vec2 | null;
+    isNavigationFinished(): boolean;
+    isTargetReachable(): boolean;
+    isTargetReached(): boolean;
+    setTarget(target: Vec2): void;
+    onNavigationStarted(cb: () => void): EventController;
+    onNavigationNext(cb: () => void): EventController;
+    onNavigationEnded(cb: () => void): EventController;
+    onTargetReached(cb: () => void): EventController;
+}
+
+/**
+ * Options for the {@link agent `agent()`} component.
+ *
+ * @group Components
+ */
+export type AgentCompOpt = {
+    speed?: number;
+    allowDiagonals?: boolean;
+};
 
 export function agent(opts: AgentCompOpt = {}): AgentComp {
     let target: Vec2 | null = null;

--- a/src/components/level/tile.ts
+++ b/src/components/level/tile.ts
@@ -1,12 +1,69 @@
 import { Vec2, vec2 } from "../../math";
 import {
+    type Comp,
     type Edge,
     EdgeMask,
     type GameObj,
     type LevelComp,
-    type TileComp,
-    type TileCompOpt,
 } from "../../types";
+
+/**
+ * The {@link tile `tile()`} component.
+ *
+ * @group Components
+ */
+export interface TileComp extends Comp {
+    /**
+     * The tile position inside the level.
+     */
+    tilePos: Vec2;
+    /**
+     * If the tile is an obstacle in pathfinding.
+     */
+    isObstacle: boolean;
+    /**
+     * How much a tile is cost to traverse in pathfinding (default 0).
+     */
+    cost: number;
+    /**
+     * If the tile has hard edges that cannot pass in pathfinding.
+     */
+    edges: Edge[];
+    /**
+     * Position offset when setting `tilePos`.
+     */
+    tilePosOffset: Vec2;
+    readonly edgeMask: EdgeMask;
+    getLevel(): GameObj<LevelComp>;
+    moveLeft(): void;
+    moveRight(): void;
+    moveUp(): void;
+    moveDown(): void;
+}
+
+/**
+ * Options for the {@link tile `tile()`} component.
+ *
+ * @group Components
+ */
+export type TileCompOpt = {
+    /**
+     * If the tile is an obstacle in pathfinding.
+     */
+    isObstacle?: boolean;
+    /**
+     * How much a tile is cost to traverse in pathfinding (default 0).
+     */
+    cost?: number;
+    /**
+     * If the tile has hard edges that cannot pass in pathfinding.
+     */
+    edges?: Edge[];
+    /**
+     * Position offset when setting `tilePos`.
+     */
+    offset?: Vec2;
+};
 
 export function tile(opts: TileCompOpt = {}): TileComp {
     let tilePos = vec2(0);

--- a/src/components/misc/health.ts
+++ b/src/components/misc/health.ts
@@ -1,5 +1,55 @@
-import type { GameObj, HealthComp } from "../../types";
+import type { Comp, GameObj } from "../../types";
 import type { EventController } from "../../utils";
+
+/**
+ * The {@link health `health()`} component.
+ *
+ * @group Components
+ */
+export interface HealthComp extends Comp {
+    /**
+     * Decrease HP by n (defaults to 1).
+     */
+    hurt(n?: number): void;
+    /**
+     * Increase HP by n (defaults to 1).
+     */
+    heal(n?: number): void;
+    /**
+     * Current health points.
+     */
+    hp(): number;
+    /**
+     * Set current health points.
+     */
+    setHP(hp: number): void;
+    /**
+     * Max amount of HP.
+     */
+    maxHP(): number | null;
+    /**
+     * Set max amount of HP.
+     */
+    setMaxHP(hp: number): void;
+    /**
+     * Register an event that runs when hurt() is called upon the object.
+     *
+     * @since v2000.1
+     */
+    onHurt(action: (amount?: number) => void): EventController;
+    /**
+     * Register an event that runs when heal() is called upon the object.
+     *
+     * @since v2000.1
+     */
+    onHeal(action: (amount?: number) => void): EventController;
+    /**
+     * Register an event that runs when object's HP is equal or below 0.
+     *
+     * @since v2000.1
+     */
+    onDeath(action: () => void): EventController;
+}
 
 export function health(
     hp: number,

--- a/src/components/misc/lifespan.ts
+++ b/src/components/misc/lifespan.ts
@@ -1,11 +1,18 @@
 import easings from "../../easings";
 import { getKaboomContext } from "../../kaboom";
-import type {
-    EmptyComp,
-    GameObj,
-    LifespanCompOpt,
-    OpacityComp,
-} from "../../types";
+import type { EmptyComp, GameObj, OpacityComp } from "../../types";
+
+/**
+ * The {@link lifespan `lifespan()`} component.
+ *
+ * @group Components
+ */
+export interface LifespanCompOpt {
+    /**
+     * Fade out duration (default 0 which is no fade out).
+     */
+    fade?: number;
+}
 
 export function lifespan(time: number, opt: LifespanCompOpt = {}): EmptyComp {
     const k = getKaboomContext(this);

--- a/src/components/misc/named.ts
+++ b/src/components/misc/named.ts
@@ -1,4 +1,14 @@
-import type { Comp, NamedComp } from "../../types";
+import type { Comp } from "../../types";
+
+/**
+ * The {@link named `named()`} component.
+ *
+ * @group Components
+ */
+export interface NamedComp extends Comp {
+    /** The name assigned to this object. */
+    name: string;
+}
 
 export function named(name: string): NamedComp {
     return {

--- a/src/components/misc/state.ts
+++ b/src/components/misc/state.ts
@@ -1,5 +1,50 @@
-import type { StateComp } from "../../types";
+import type { Comp } from "../../types";
 import { Event, EventController } from "../../utils";
+
+/**
+ * The {@link state `state()`} component.
+ *
+ * @group Components
+ */
+export interface StateComp extends Comp {
+    /**
+     * Current state.
+     */
+    state: string;
+    /**
+     * Enter a state, trigger onStateEnd for previous state and onStateEnter for the new State state.
+     */
+    enterState: (state: string, ...args: any) => void;
+    /**
+     * Register event that runs once when a specific state transition happens. Accepts arguments passed from `enterState(name, ...args)`.
+     *
+     * @since v2000.2
+     */
+    onStateTransition(
+        from: string,
+        to: string,
+        action: () => void,
+    ): EventController;
+    /**
+     * Register event that runs once when enters a specific state. Accepts arguments passed from `enterState(name, ...args)`.
+     */
+    onStateEnter: (
+        state: string,
+        action: (...args: any) => void,
+    ) => EventController;
+    /**
+     * Register an event that runs once when leaves a specific state.
+     */
+    onStateEnd: (state: string, action: () => void) => EventController;
+    /**
+     * Register an event that runs every frame when in a specific state.
+     */
+    onStateUpdate: (state: string, action: () => void) => EventController;
+    /**
+     * Register an event that runs every frame when in a specific state.
+     */
+    onStateDraw: (state: string, action: () => void) => EventController;
+}
 
 export function state(
     initState: string,

--- a/src/components/misc/stay.ts
+++ b/src/components/misc/stay.ts
@@ -1,4 +1,20 @@
-import type { StayComp } from "../../types";
+import type { Comp } from "../../types";
+
+/**
+ * The {@link stay `stay()`} component.
+ *
+ * @group Components
+ */
+export interface StayComp extends Comp {
+    /**
+     * If the obj should not be destroyed on scene switch.
+     */
+    stay: boolean;
+    /**
+     * Array of scenes that the obj will stay on.
+     */
+    scenesToStay: string[];
+}
 
 export function stay(scenesToStay?: string[]): StayComp {
     return {

--- a/src/components/misc/timer.ts
+++ b/src/components/misc/timer.ts
@@ -2,12 +2,43 @@ import easings from "../../easings";
 import { getKaboomContext } from "../../kaboom";
 import { lerp } from "../../math";
 import type {
+    Comp,
     EventController,
     GameObj,
     LerpValue,
-    TimerComp,
     TimerController,
+    TweenController,
 } from "../../types";
+
+/**
+ * The {@link timer `timer()`} component.
+ *
+ * @group Componens
+ */
+export interface TimerComp extends Comp {
+    /**
+     * Run the callback after n seconds.
+     */
+    wait(time: number, action?: () => void): TimerController;
+    /**
+     * Run the callback every n seconds.
+     *
+     * @since v3000.0
+     */
+    loop(time: number, action: () => void): EventController;
+    /**
+     * Tweeeeen! Note that this doesn't specifically mean tweening on this object's property, this just registers the timer on this object, so the tween will cancel with the object gets destroyed, or paused when obj.paused is true.
+     *
+     * @since v3000.0
+     */
+    tween<V extends LerpValue>(
+        from: V,
+        to: V,
+        duration: number,
+        setValue: (value: V) => void,
+        easeFunc?: (t: number) => number,
+    ): TweenController;
+}
 
 export function timer(): TimerComp {
     return {

--- a/src/components/physics/area.ts
+++ b/src/components/physics/area.ts
@@ -1,12 +1,10 @@
 import { DEF_ANCHOR } from "../../constants";
-import { anchorPt, getInternalContext, getKaboomContext } from "../../kaboom";
+import { anchorPt, getKaboomContext } from "../../kaboom";
 import { Polygon, rgb, testPolygonPoint, Vec2, vec2 } from "../../math";
 import type {
-    AnchorComp,
-    AreaComp,
-    AreaCompOpt,
     Collision,
-    FixedComp,
+    Comp,
+    Cursor,
     GameObj,
     MouseButton,
     PosComp,
@@ -14,11 +12,200 @@ import type {
     Tag,
 } from "../../types";
 import type { EventController } from "../../utils";
+import type { AnchorComp } from "../transform/anchor";
+import type { FixedComp } from "../transform/fixed";
+
+/**
+ * The {@link area `area()`} component.
+ *
+ * @group Components
+ */
+export interface AreaComp extends Comp {
+    /**
+     * Collider area info.
+     */
+    area: {
+        /**
+         * If we use a custom shape over render shape.
+         */
+        shape: Shape | null;
+        /**
+         * Area scale.
+         */
+        scale: Vec2;
+        /**
+         * Area offset.
+         */
+        offset: Vec2;
+        /**
+         * Cursor on hover.
+         */
+        cursor: Cursor | null;
+    };
+    /**
+     * If this object should ignore collisions against certain other objects.
+     *
+     * @since v3000.0
+     */
+    collisionIgnore: Tag[];
+    /**
+     * If was just clicked on last frame.
+     */
+    isClicked(): boolean;
+    /**
+     * If is being hovered on.
+     */
+    isHovering(): boolean;
+    /**
+     * Check collision with another game obj.
+     *
+     * @since v3000.0
+     */
+    checkCollision(other: GameObj<AreaComp>): Collision | null;
+    /**
+     * Get all collisions currently happening.
+     *
+     * @since v3000.0
+     */
+    getCollisions(): Collision[];
+    /**
+     * If is currently colliding with another game obj.
+     */
+    isColliding(o: GameObj<AreaComp>): boolean;
+    /**
+     * If is currently overlapping with another game obj (like isColliding, but will return false if the objects are just touching edges).
+     */
+    isOverlapping(o: GameObj<AreaComp>): boolean;
+    /**
+     * Register an event runs when clicked.
+     *
+     * @since v2000.1
+     */
+    onClick(f: () => void, btn?: MouseButton): void;
+    /**
+     * Register an event runs once when hovered.
+     *
+     * @since v3000.0
+     */
+    onHover(action: () => void): EventController;
+    /**
+     * Register an event runs every frame when hovered.
+     *
+     * @since v3000.0
+     */
+    onHoverUpdate(action: () => void): EventController;
+    /**
+     * Register an event runs once when unhovered.
+     *
+     * @since v3000.0
+     */
+    onHoverEnd(action: () => void): EventController;
+    /**
+     * Register an event runs once when collide with another game obj with certain tag.
+     *
+     * @since v2001.0
+     */
+    onCollide(tag: Tag, f: (obj: GameObj, col?: Collision) => void): void;
+    /**
+     * Register an event runs once when collide with another game obj.
+     *
+     * @since v2000.1
+     */
+    onCollide(f: (obj: GameObj, col?: Collision) => void): void;
+    /**
+     * Register an event runs every frame when collide with another game obj with certain tag.
+     *
+     * @since v3000.0
+     */
+    onCollideUpdate(
+        tag: Tag,
+        f: (obj: GameObj, col?: Collision) => void,
+    ): EventController;
+    /**
+     * Register an event runs every frame when collide with another game obj.
+     *
+     * @since v3000.0
+     */
+    onCollideUpdate(
+        f: (obj: GameObj, col?: Collision) => void,
+    ): EventController;
+    /**
+     * Register an event runs once when stopped colliding with another game obj with certain tag.
+     *
+     * @since v3000.0
+     */
+    onCollideEnd(tag: Tag, f: (obj: GameObj) => void): EventController;
+    /**
+     * Register an event runs once when stopped colliding with another game obj.
+     *
+     * @since v3000.0
+     */
+    onCollideEnd(f: (obj: GameObj) => void): void;
+    /**
+     * If has a certain point inside collider.
+     */
+    hasPoint(p: Vec2): boolean;
+    /**
+     * Push out from another solid game obj if currently overlapping.
+     */
+    resolveCollision(obj: GameObj): void;
+    /**
+     * Get the geometry data for the collider in local coordinate space.
+     *
+     * @since v3000.0
+     */
+    localArea(): Shape;
+    /**
+     * Get the geometry data for the collider in world coordinate space.
+     */
+    worldArea(): Polygon;
+    /**
+     * Get the geometry data for the collider in screen coordinate space.
+     */
+    screenArea(): Polygon;
+}
+
+/**
+ * Options for the {@link area `area()`} component.
+ */
+export interface AreaCompOpt {
+    /**
+     * The shape of the area (currently only Rect and Polygon is supported).
+     *
+     * @example
+     * ```js
+     * add([
+     *     sprite("butterfly"),
+     *     pos(100, 200),
+     *     // a triangle shape!
+     *     area({ shape: new Polygon([vec2(0), vec2(100), vec2(-100, 100)]) }),
+     * ])
+     * ```
+     */
+    shape?: Shape;
+    /**
+     * Area scale.
+     */
+    scale?: number | Vec2;
+    /**
+     * Area offset.
+     */
+    offset?: Vec2;
+    /**
+     * Cursor on hover.
+     */
+    cursor?: Cursor;
+    /**
+     * If this object should ignore collisions against certain other objects.
+     *
+     * @since v3000.0
+     */
+    collisionIgnore?: Tag[];
+}
 
 export function area(opt: AreaCompOpt = {}): AreaComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
-    const { app } = internal;
+    const { app, isFixed, getViewportScale, game } = k._k;
 
     const colliding = {};
     const collidingThisFrame = new Set();
@@ -60,12 +247,12 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
 
             const opts = {
                 outline: {
-                    width: 4 / internal.getViewportScale(),
+                    width: 4 / getViewportScale(),
                     color: rgb(0, 0, 255),
                 },
                 anchor: this.anchor,
                 fill: false,
-                fixed: internal.isFixed(this),
+                fixed: isFixed(this),
             };
 
             if (a instanceof k.Rect) {
@@ -103,7 +290,7 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
         },
 
         isHovering(this: GameObj) {
-            const mpos = internal.isFixed(this)
+            const mpos = isFixed(this)
                 ? k.mousePos()
                 : k.toWorld(k.mousePos());
             return this.hasPoint(mpos);
@@ -278,10 +465,10 @@ export function area(opt: AreaCompOpt = {}): AreaComp {
 
         screenArea(this: GameObj<AreaComp | FixedComp>): Polygon {
             const area = this.worldArea();
-            if (internal.isFixed(this)) {
+            if (isFixed(this)) {
                 return area;
             } else {
-                return area.transform(internal.game.cam.transform);
+                return area.transform(game.cam.transform);
             }
         },
 

--- a/src/components/physics/doubleJump.ts
+++ b/src/components/physics/doubleJump.ts
@@ -1,5 +1,26 @@
-import type { BodyComp, DoubleJumpComp, GameObj } from "../../types";
+import type { Comp, GameObj } from "../../types";
 import type { EventController } from "../../utils";
+import type { BodyComp } from "./body";
+
+/**
+ * The {@link doubleJump `doubleJump()`} component.
+ *
+ * @group Components
+ */
+export interface DoubleJumpComp extends Comp {
+    /**
+     * Number of jumps allowed.
+     */
+    numJumps: number;
+    /**
+     * Performs double jump (the initial jump only happens if player is grounded).
+     */
+    doubleJump(force?: number): void;
+    /**
+     * Register an event that runs when the object performs the second jump when double jumping.
+     */
+    onDoubleJump(action: () => void): EventController;
+}
 
 export function doubleJump(numJumps: number = 2): DoubleJumpComp {
     let jumpsLeft = numJumps;

--- a/src/components/transform/anchor.ts
+++ b/src/components/transform/anchor.ts
@@ -1,5 +1,17 @@
 import type { Vec2 } from "../../math";
-import type { Anchor, AnchorComp } from "../../types";
+import type { Anchor, Comp } from "../../types";
+
+/**
+ * The {@link anchor `anchor()`} component.
+ *
+ * @group Components
+ */
+export interface AnchorComp extends Comp {
+    /**
+     * Anchor point for render.
+     */
+    anchor: Anchor | Vec2;
+}
 
 export function anchor(o: Anchor | Vec2): AnchorComp {
     if (!o) {

--- a/src/components/transform/fixed.ts
+++ b/src/components/transform/fixed.ts
@@ -1,4 +1,16 @@
-import type { FixedComp } from "../../types";
+import type { Comp } from "../../types";
+
+/**
+ * The {@link fixed `fixed()`} component.
+ *
+ * @group Componens
+ */
+export interface FixedComp extends Comp {
+    /**
+     * If the obj is unaffected by camera
+     */
+    fixed: boolean;
+}
 
 export function fixed(): FixedComp {
     return {

--- a/src/components/transform/follow.ts
+++ b/src/components/transform/follow.ts
@@ -1,5 +1,18 @@
 import { Vec2, vec2 } from "../../math";
-import type { FollowComp, GameObj, PosComp } from "../../types";
+import type { Comp, GameObj } from "../../types";
+import type { PosComp } from "./pos";
+
+/**
+ * The {@link follow `follow()`} component.
+ *
+ * @group Components
+ */
+export interface FollowComp extends Comp {
+    follow: {
+        obj: GameObj;
+        offset: Vec2;
+    };
+}
 
 export function follow(obj: GameObj, offset?: Vec2): FollowComp {
     return {

--- a/src/components/transform/layer.ts
+++ b/src/components/transform/layer.ts
@@ -1,10 +1,28 @@
-import { getInternalContext, getKaboomContext } from "../../kaboom";
-import type { LayerComp } from "../../types";
+import { getKaboomContext } from "../../kaboom";
+import type { Comp } from "../../types";
+
+/**
+ * The {@link layer `layer()`} component.
+ *
+ * @group Components
+ */
+export interface LayerComp extends Comp {
+    get layerIndex(): number;
+    /**
+     * Get the name of the current layer the object is assigned to.
+     */
+    get layer(): string;
+    /**
+     * Set the name of the layer the object should be assigned to.
+     */
+    set layer(name: string);
+}
 
 export function layer(layer: string): LayerComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
-    let _layerIndex = internal.game.layers.indexOf(layer);
+    const { game } = k._k;
+
+    let _layerIndex = game.layers.indexOf(layer);
     return {
         id: "layer",
         get layerIndex() {
@@ -14,7 +32,7 @@ export function layer(layer: string): LayerComp {
             return k.layers[_layerIndex];
         },
         set layer(value: string) {
-            _layerIndex = internal.game.layers.indexOf(value);
+            _layerIndex = game.layers.indexOf(value);
             if (_layerIndex == -1) throw Error("Invalid layer name");
         },
         inspect() {

--- a/src/components/transform/move.ts
+++ b/src/components/transform/move.ts
@@ -1,5 +1,6 @@
 import { Vec2 } from "../../math";
-import type { EmptyComp, GameObj, PosComp } from "../../types";
+import type { EmptyComp, GameObj } from "../../types";
+import type { PosComp } from "./pos";
 
 export function move(dir: number | Vec2, speed: number): EmptyComp {
     const d = typeof dir === "number" ? Vec2.fromAngle(dir) : dir.unit();

--- a/src/components/transform/offscreen.ts
+++ b/src/components/transform/offscreen.ts
@@ -1,13 +1,55 @@
 import { DEF_OFFSCREEN_DIS } from "../../constants";
 import { getKaboomContext } from "../../kaboom";
 import { Rect, vec2 } from "../../math";
-import type {
-    GameObj,
-    OffScreenComp,
-    OffScreenCompOpt,
-    PosComp,
-} from "../../types";
+import type { Comp, GameObj } from "../../types";
 import type { EventController } from "../../utils";
+import type { PosComp } from "./pos";
+
+/**
+ * The {@link offscreen `offscreen()`} component.
+ *
+ * @group Components
+ */
+export interface OffScreenComp extends Comp {
+    /**
+     * If object is currently out of view.
+     */
+    isOffScreen(): boolean;
+    /**
+     * Register an event that runs when object goes out of view.
+     */
+    onExitScreen(action: () => void): EventController;
+    /**
+     * Register an event that runs when object enters view.
+     */
+    onEnterScreen(action: () => void): EventController;
+}
+
+/**
+ * Options for {@link offscreen `offscreen()`} component.
+ *
+ * @group Components
+ */
+export interface OffScreenCompOpt {
+    /**
+     * If hide object when out of view.
+     */
+    hide?: boolean;
+    /**
+     * If pause object when out of view.
+     */
+    pause?: boolean;
+    /**
+     * If destroy object when out of view.
+     */
+    destroy?: boolean;
+    /**
+     * The distance when out of view is triggered (default 200).
+     *
+     * @since v3000.0
+     */
+    distance?: number;
+}
 
 export function offscreen(opt: OffScreenCompOpt = {}): OffScreenComp {
     const k = getKaboomContext(this);

--- a/src/components/transform/pos.ts
+++ b/src/components/transform/pos.ts
@@ -1,6 +1,71 @@
-import { getInternalContext, getKaboomContext } from "../../kaboom";
+import { getKaboomContext } from "../../kaboom";
 import { Vec2, vec2 } from "../../math";
-import type { FixedComp, GameObj, PosComp, Vec2Args } from "../../types";
+import type { Comp, GameObj, Vec2Args } from "../../types";
+import type { FixedComp } from "./fixed";
+
+/**
+ * The {@link pos `pos()`} component.
+ *
+ * @group Components
+ */
+export interface PosComp extends Comp {
+    /**
+     * Object's current world position.
+     */
+    pos: Vec2;
+    /**
+     * Move how many pixels per second. If object is 'solid', it won't move into other 'solid' objects.
+     */
+    move(xVel: number, yVel: number): void;
+    move(vel: Vec2): void;
+    /**
+     * Move how many pixels, without multiplying dt, but still checking for 'solid'.
+     */
+    moveBy(dx: number, dy: number): void;
+    moveBy(d: Vec2): void;
+    /**
+     * Move to a spot with a speed (pixels per second), teleports if speed is not given.
+     */
+    moveTo(dest: Vec2, speed?: number): void;
+    moveTo(x: number, y: number, speed?: number): void;
+    /**
+     * Get the position of the object on the screen.
+     */
+    screenPos(): Vec2;
+    /**
+     * Get the position of the object relative to the root.
+     */
+    worldPos(): Vec2;
+    /**
+     * Transform a local point (relative to this) to a screen point (relative to the camera)
+     */
+    toScreen(this: GameObj<PosComp | FixedComp>, p: Vec2);
+    /**
+     * Transform a local point (relative to this) to a world point (relative to the root)
+     * @since v3001.0
+     */
+    toWorld(this: GameObj<PosComp>, p: Vec2);
+    /**
+     * Transform a screen point (relative to the camera) to a local point (relative to this)
+     * @since v3001.0
+     */
+    fromScreen(this: GameObj<PosComp | FixedComp>, p: Vec2);
+    /**
+     * Transform a world point (relative to the root) to a local point (relative to this)
+     * @since v3001.0
+     */
+    fromWorld(this: GameObj<PosComp>, p: Vec2);
+    /**
+     * Transform a point relative to this to a point relative to other
+     * @since v3001.0
+     */
+    toOther(this: GameObj<PosComp>, other: GameObj<PosComp>, p: Vec2);
+    /**
+     * Transform a point relative to other to a point relative to this
+     * @since v3001.0
+     */
+    fromOther(this: GameObj<PosComp>, other: GameObj<PosComp>, p: Vec2);
+}
 
 function isFixed(obj: GameObj) {
     if (obj.fixed) return true;
@@ -9,7 +74,7 @@ function isFixed(obj: GameObj) {
 
 export function pos(...args: Vec2Args): PosComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
+    const { getViewportScale } = k._k;
 
     return {
         id: "pos",
@@ -117,7 +182,7 @@ export function pos(...args: Vec2Args): PosComp {
         drawInspect() {
             k.drawCircle({
                 color: k.rgb(255, 0, 0),
-                radius: 4 / internal.getViewportScale(),
+                radius: 4 / getViewportScale(),
             });
         },
     };

--- a/src/components/transform/rotate.ts
+++ b/src/components/transform/rotate.ts
@@ -1,4 +1,26 @@
-import type { RotateComp } from "../../types";
+import type { Comp } from "../../types";
+
+/**
+ * The {@link rotate `rotate()`} component.
+ *
+ * @group Components
+ */
+export interface RotateComp extends Comp {
+    /**
+     * Angle in degrees.
+     */
+    angle: number;
+    /**
+     * Rotate in degrees.
+     */
+    rotateBy(angle: number): void;
+    /**
+     * Rotate to a degree (like directly assign to .angle)
+     *
+     * @since v3000.0
+     */
+    rotateTo(s: number): void;
+}
 
 export function rotate(r: number): RotateComp {
     return {

--- a/src/components/transform/scale.ts
+++ b/src/components/transform/scale.ts
@@ -1,11 +1,26 @@
-import { getInternalContext, getKaboomContext } from "../../kaboom";
-import { vec2 } from "../../math";
-import type { ScaleComp, Vec2Args } from "../../types";
+import { getKaboomContext } from "../../kaboom";
+import { type Vec2, vec2 } from "../../math";
+import type { Comp, Vec2Args } from "../../types";
+
+/**
+ * The {@link scale `scale()`} component.
+ *
+ * @group Components
+ */
+export interface ScaleComp extends Comp {
+    scale: Vec2;
+    scaleTo(s: number): void;
+    scaleTo(s: Vec2): void;
+    scaleTo(sx: number, sy: number): void;
+    scaleBy(s: number): void;
+    scaleBy(s: Vec2): void;
+    scaleBy(sx: number, sy: number): void;
+}
 
 // TODO: allow single number assignment
 export function scale(...args: Vec2Args): ScaleComp {
     const k = getKaboomContext(this);
-    const internal = getInternalContext(k);
+    const { toFixed } = k._k;
 
     if (args.length === 0) {
         return scale(1);
@@ -20,9 +35,7 @@ export function scale(...args: Vec2Args): ScaleComp {
             this.scale.scale(vec2(...args));
         },
         inspect() {
-            return `(${internal.toFixed(this.scale.x, 2)}, ${
-                internal.toFixed(this.scale.y, 2)
-            })`;
+            return `(${toFixed(this.scale.x, 2)}, ${toFixed(this.scale.y, 2)})`;
         },
     };
 }

--- a/src/components/transform/z.ts
+++ b/src/components/transform/z.ts
@@ -1,4 +1,16 @@
-import type { ZComp } from "../../types";
+import type { Comp } from "../../types";
+
+/**
+ * The {@link z `z()`} component.
+ *
+ * @group Components
+ */
+export interface ZComp extends Comp {
+    /**
+     * Defines the z-index of this game obj
+     */
+    z: number;
+}
 
 export function z(z: number): ZComp {
     return {

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -131,7 +131,6 @@ import type {
     BitmapFontData,
     BoomOpt,
     CharTransform,
-    ColorComp,
     Comp,
     CompList,
     Debug,
@@ -233,6 +232,7 @@ import beanSpriteSrc from "./assets/bean.png";
 import boomSpriteSrc from "./assets/boom.png";
 import burpSoundSrc from "./assets/burp.mp3";
 import kaSpriteSrc from "./assets/ka.png";
+import { color } from "./components/draw/color";
 
 // convert anchor string to a vec2 offset
 export function anchorPt(orig: Anchor | Vec2): Vec2 {
@@ -296,10 +296,6 @@ export const getKaboomContext = (fallBack?: any): KaboomCtx => {
     }
 
     return ctx;
-};
-
-export const getInternalContext = (kaboom: KaboomCtx): InternalCtx => {
-    return kaboom._k;
 };
 
 // only exports one kaplay() which contains all the state
@@ -3992,16 +3988,6 @@ const kaplay = (gopt: KaboomOpt = {}): KaboomCtx => {
 
     function getBackground() {
         return gfx.bgColor.clone();
-    }
-
-    function color(...args): ColorComp {
-        return {
-            id: "color",
-            color: rgb(...args),
-            inspect() {
-                return this.color.toString();
-            },
-        };
     }
 
     function toFixed(n: number, f: number) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,98 @@
 import type { Asset } from "./assets";
+import type {
+    AgentComp,
+    AgentCompOpt,
+    AnchorComp,
+    AreaComp,
+    AreaCompOpt,
+    BodyComp,
+    BodyCompOpt,
+    CircleComp,
+    ColorComp,
+    DoubleJumpComp,
+    FixedComp,
+    FollowComp,
+    HealthComp,
+    LayerComp,
+    LifespanCompOpt,
+    MaskComp,
+    NamedComp,
+    OffScreenComp,
+    OffScreenCompOpt,
+    OpacityComp,
+    OutlineComp,
+    PolygonComp,
+    PolygonCompOpt,
+    PosComp,
+    RectComp,
+    RectCompOpt,
+    RotateComp,
+    ScaleComp,
+    ShaderComp,
+    SpriteComp,
+    SpriteCompOpt,
+    StateComp,
+    StayComp,
+    TextComp,
+    TextCompOpt,
+    TileComp,
+    TileCompOpt,
+    TimerComp,
+    UVQuadComp,
+    ZComp,
+} from "./components/";
 import type { FontData } from "./fonts";
 import type { Vec2 } from "./math";
 import type { Event, EventController, EventHandler } from "./utils";
 
-export type { Asset, Event, EventController, EventHandler, FontData, Vec2 };
+export type {
+    AgentComp,
+    AgentCompOpt,
+    AnchorComp,
+    AreaComp,
+    AreaCompOpt,
+    Asset,
+    BodyComp,
+    BodyCompOpt,
+    CircleComp,
+    ColorComp,
+    DoubleJumpComp,
+    Event,
+    EventController,
+    EventHandler,
+    FixedComp,
+    FollowComp,
+    FontData,
+    HealthComp,
+    LayerComp,
+    LifespanCompOpt,
+    MaskComp,
+    NamedComp,
+    OffScreenComp,
+    OffScreenCompOpt,
+    OpacityComp,
+    OutlineComp,
+    PolygonComp,
+    PolygonCompOpt,
+    PosComp,
+    RectComp,
+    RectCompOpt,
+    RotateComp,
+    ScaleComp,
+    ShaderComp,
+    SpriteComp,
+    SpriteCompOpt,
+    StateComp,
+    StayComp,
+    TextComp,
+    TextCompOpt,
+    TileComp,
+    TileCompOpt,
+    TimerComp,
+    UVQuadComp,
+    Vec2,
+    ZComp,
+};
 
 /**
  * Initialize KAPLAY context. The starting point of all KAPLAY games.
@@ -5193,7 +5282,7 @@ export declare class RNG {
 }
 
 /**
- * @group Component System
+ * @group Components
  */
 export interface Comp {
     /**
@@ -5240,212 +5329,14 @@ export type GameObjID = number;
 /**
  * A component without own properties.
  *
- * @group Component System
+ * @group Components
  */
 export type EmptyComp = { id: string } & Comp;
 
 /**
- * @group Component System
- */
-export interface PosComp extends Comp {
-    /**
-     * Object's current world position.
-     */
-    pos: Vec2;
-    /**
-     * Move how many pixels per second. If object is 'solid', it won't move into other 'solid' objects.
-     */
-    move(xVel: number, yVel: number): void;
-    move(vel: Vec2): void;
-    /**
-     * Move how many pixels, without multiplying dt, but still checking for 'solid'.
-     */
-    moveBy(dx: number, dy: number): void;
-    moveBy(d: Vec2): void;
-    /**
-     * Move to a spot with a speed (pixels per second), teleports if speed is not given.
-     */
-    moveTo(dest: Vec2, speed?: number): void;
-    moveTo(x: number, y: number, speed?: number): void;
-    /**
-     * Get the position of the object on the screen.
-     */
-    screenPos(): Vec2;
-    /**
-     * Get the position of the object relative to the root.
-     */
-    worldPos(): Vec2;
-    /**
-     * Transform a local point (relative to this) to a screen point (relative to the camera)
-     */
-    toScreen(this: GameObj<PosComp | FixedComp>, p: Vec2);
-    /**
-     * Transform a local point (relative to this) to a world point (relative to the root)
-     * @since v3001.0
-     */
-    toWorld(this: GameObj<PosComp>, p: Vec2);
-    /**
-     * Transform a screen point (relative to the camera) to a local point (relative to this)
-     * @since v3001.0
-     */
-    fromScreen(this: GameObj<PosComp | FixedComp>, p: Vec2);
-    /**
-     * Transform a world point (relative to the root) to a local point (relative to this)
-     * @since v3001.0
-     */
-    fromWorld(this: GameObj<PosComp>, p: Vec2);
-    /**
-     * Transform a point relative to this to a point relative to other
-     * @since v3001.0
-     */
-    toOther(this: GameObj<PosComp>, other: GameObj<PosComp>, p: Vec2);
-    /**
-     * Transform a point relative to other to a point relative to this
-     * @since v3001.0
-     */
-    fromOther(this: GameObj<PosComp>, other: GameObj<PosComp>, p: Vec2);
-}
-
-/**
- * @group Component System
- */
-export interface ScaleComp extends Comp {
-    scale: Vec2;
-    scaleTo(s: number): void;
-    scaleTo(s: Vec2): void;
-    scaleTo(sx: number, sy: number): void;
-    scaleBy(s: number): void;
-    scaleBy(s: Vec2): void;
-    scaleBy(sx: number, sy: number): void;
-}
-
-/**
- * @group Component System
- */
-export interface RotateComp extends Comp {
-    /**
-     * Angle in degrees.
-     */
-    angle: number;
-    /**
-     * Rotate in degrees.
-     */
-    rotateBy(angle: number): void;
-    /**
-     * Rotate to a degree (like directly assign to .angle)
-     *
-     * @since v3000.0
-     */
-    rotateTo(s: number): void;
-}
-
-/**
- * @group Component System
- */
-export interface ColorComp extends Comp {
-    color: Color;
-}
-
-/**
- * @group Component System
- */
-export interface OpacityComp extends Comp {
-    opacity: number;
-    fadeIn(time?: number, easeFunc?: EaseFunc): TweenController;
-    fadeOut(time?: number, easeFunc?: EaseFunc): TweenController;
-}
-
-/**
- * @group Component System
- */
-export interface AnchorComp extends Comp {
-    /**
-     * Anchor point for render.
-     */
-    anchor: Anchor | Vec2;
-}
-
-/**
- * @group Component System
- */
-export interface ZComp extends Comp {
-    /**
-     * Defines the z-index of this game obj
-     */
-    z: number;
-}
-
-/**
- * @group Component System
- */
-export interface FollowComp extends Comp {
-    follow: {
-        obj: GameObj;
-        offset: Vec2;
-    };
-}
-
-/**
- * @group Component System
- */
-export interface OffScreenCompOpt {
-    /**
-     * If hide object when out of view.
-     */
-    hide?: boolean;
-    /**
-     * If pause object when out of view.
-     */
-    pause?: boolean;
-    /**
-     * If destroy object when out of view.
-     */
-    destroy?: boolean;
-    /**
-     * The distance when out of view is triggered (default 200).
-     *
-     * @since v3000.0
-     */
-    distance?: number;
-}
-
-/**
- * @group Component System
- */
-export interface OffScreenComp extends Comp {
-    /**
-     * If object is currently out of view.
-     */
-    isOffScreen(): boolean;
-    /**
-     * Register an event that runs when object goes out of view.
-     */
-    onExitScreen(action: () => void): EventController;
-    /**
-     * Register an event that runs when object enters view.
-     */
-    onEnterScreen(action: () => void): EventController;
-}
-
-/**
- * @group Component System
- */
-export interface LayerComp extends Comp {
-    get layerIndex(): number;
-    /**
-     * Get the name of the current layer the object is assigned to.
-     */
-    get layer(): string;
-    /**
-     * Set the name of the layer the object should be assigned to.
-     */
-    set layer(name: string);
-}
-
-/**
  * Collision resolution data.
  *
- * @group Component System
+ * @group Components
  */
 export interface Collision {
     /**
@@ -5499,545 +5390,6 @@ export interface Collision {
 }
 
 /**
- * @group Options
- */
-export interface AreaCompOpt {
-    /**
-     * The shape of the area (currently only Rect and Polygon is supported).
-     *
-     * @example
-     * ```js
-     * add([
-     *     sprite("butterfly"),
-     *     pos(100, 200),
-     *     // a triangle shape!
-     *     area({ shape: new Polygon([vec2(0), vec2(100), vec2(-100, 100)]) }),
-     * ])
-     * ```
-     */
-    shape?: Shape;
-    /**
-     * Area scale.
-     */
-    scale?: number | Vec2;
-    /**
-     * Area offset.
-     */
-    offset?: Vec2;
-    /**
-     * Cursor on hover.
-     */
-    cursor?: Cursor;
-    /**
-     * If this object should ignore collisions against certain other objects.
-     *
-     * @since v3000.0
-     */
-    collisionIgnore?: Tag[];
-}
-
-/**
- * @group Component System
- */
-export interface AreaComp extends Comp {
-    /**
-     * Collider area info.
-     */
-    area: {
-        /**
-         * If we use a custom shape over render shape.
-         */
-        shape: Shape | null;
-        /**
-         * Area scale.
-         */
-        scale: Vec2;
-        /**
-         * Area offset.
-         */
-        offset: Vec2;
-        /**
-         * Cursor on hover.
-         */
-        cursor: Cursor | null;
-    };
-    /**
-     * If this object should ignore collisions against certain other objects.
-     *
-     * @since v3000.0
-     */
-    collisionIgnore: Tag[];
-    /**
-     * If was just clicked on last frame.
-     */
-    isClicked(): boolean;
-    /**
-     * If is being hovered on.
-     */
-    isHovering(): boolean;
-    /**
-     * Check collision with another game obj.
-     *
-     * @since v3000.0
-     */
-    checkCollision(other: GameObj<AreaComp>): Collision | null;
-    /**
-     * Get all collisions currently happening.
-     *
-     * @since v3000.0
-     */
-    getCollisions(): Collision[];
-    /**
-     * If is currently colliding with another game obj.
-     */
-    isColliding(o: GameObj<AreaComp>): boolean;
-    /**
-     * If is currently overlapping with another game obj (like isColliding, but will return false if the objects are just touching edges).
-     */
-    isOverlapping(o: GameObj<AreaComp>): boolean;
-    /**
-     * Register an event runs when clicked.
-     *
-     * @since v2000.1
-     */
-    onClick(f: () => void, btn?: MouseButton): void;
-    /**
-     * Register an event runs once when hovered.
-     *
-     * @since v3000.0
-     */
-    onHover(action: () => void): EventController;
-    /**
-     * Register an event runs every frame when hovered.
-     *
-     * @since v3000.0
-     */
-    onHoverUpdate(action: () => void): EventController;
-    /**
-     * Register an event runs once when unhovered.
-     *
-     * @since v3000.0
-     */
-    onHoverEnd(action: () => void): EventController;
-    /**
-     * Register an event runs once when collide with another game obj with certain tag.
-     *
-     * @since v2001.0
-     */
-    onCollide(tag: Tag, f: (obj: GameObj, col?: Collision) => void): void;
-    /**
-     * Register an event runs once when collide with another game obj.
-     *
-     * @since v2000.1
-     */
-    onCollide(f: (obj: GameObj, col?: Collision) => void): void;
-    /**
-     * Register an event runs every frame when collide with another game obj with certain tag.
-     *
-     * @since v3000.0
-     */
-    onCollideUpdate(
-        tag: Tag,
-        f: (obj: GameObj, col?: Collision) => void,
-    ): EventController;
-    /**
-     * Register an event runs every frame when collide with another game obj.
-     *
-     * @since v3000.0
-     */
-    onCollideUpdate(
-        f: (obj: GameObj, col?: Collision) => void,
-    ): EventController;
-    /**
-     * Register an event runs once when stopped colliding with another game obj with certain tag.
-     *
-     * @since v3000.0
-     */
-    onCollideEnd(tag: Tag, f: (obj: GameObj) => void): EventController;
-    /**
-     * Register an event runs once when stopped colliding with another game obj.
-     *
-     * @since v3000.0
-     */
-    onCollideEnd(f: (obj: GameObj) => void): void;
-    /**
-     * If has a certain point inside collider.
-     */
-    hasPoint(p: Vec2): boolean;
-    /**
-     * Push out from another solid game obj if currently overlapping.
-     */
-    resolveCollision(obj: GameObj): void;
-    /**
-     * Get the geometry data for the collider in local coordinate space.
-     *
-     * @since v3000.0
-     */
-    localArea(): Shape;
-    /**
-     * Get the geometry data for the collider in world coordinate space.
-     */
-    worldArea(): Polygon;
-    /**
-     * Get the geometry data for the collider in screen coordinate space.
-     */
-    screenArea(): Polygon;
-}
-
-/**
- * @group Options
- */
-export interface SpriteCompOpt {
-    /**
-     * If the sprite is loaded with multiple frames, or sliced, use the frame option to specify which frame to draw.
-     */
-    frame?: number;
-    /**
-     * If provided width and height, don't stretch but instead render tiled.
-     */
-    tiled?: boolean;
-    /**
-     * Stretch sprite to a certain width.
-     */
-    width?: number;
-    /**
-     * Stretch sprite to a certain height.
-     */
-    height?: number;
-    /**
-     * Play an animation on start.
-     */
-    anim?: string;
-    /**
-     * Speed multiplier for all animations (for the actual fps for an anim use .play("anim", { speed: 10 })).
-     */
-    animSpeed?: number;
-    /**
-     * Flip texture horizontally.
-     */
-    flipX?: boolean;
-    /**
-     * Flip texture vertically.
-     */
-    flipY?: boolean;
-    /**
-     * The rectangular sub-area of the texture to render, default to full texture `quad(0, 0, 1, 1)`.
-     */
-    quad?: Quad;
-    /**
-     * If fill the sprite (useful if you only want to render outline with outline() component).
-     */
-    fill?: boolean;
-}
-
-/**
- * @group Component System
- */
-export interface SpriteComp extends Comp {
-    draw: Comp["draw"];
-    /**
-     * Name of the sprite.
-     */
-    sprite: string;
-    /**
-     * Width for sprite.
-     */
-    width: number;
-    /**
-     * Height for sprite.
-     */
-    height: number;
-    /**
-     * Current frame.
-     */
-    frame: number;
-    /**
-     * The rectangular area of the texture to render.
-     */
-    quad: Quad;
-    /**
-     * Play a piece of anim.
-     */
-    play(anim: string, options?: SpriteAnimPlayOpt): void;
-    /**
-     * Stop current anim.
-     */
-    stop(): void;
-    /**
-     * Get total number of frames.
-     */
-    numFrames(): number;
-    /**
-     * Get the current animation data.
-     *
-     * @since v3001.0
-     */
-    getCurAnim(): SpriteCurAnim;
-    /**
-     * Get current anim name.
-     *
-     * @deprecated Use `getCurrentAnim().name` instead.
-     */
-    curAnim(): string;
-    /**
-     * Speed multiplier for all animations (for the actual fps for an anim use .play("anim", { speed: 10 })).
-     */
-    animSpeed: number;
-    /**
-     * Flip texture horizontally.
-     */
-    flipX: boolean;
-    /**
-     * Flip texture vertically.
-     */
-    flipY: boolean;
-    /**
-     * Register an event that runs when an animation is played.
-     */
-    onAnimStart(action: (anim: string) => void): EventController;
-    /**
-     * Register an event that runs when an animation is ended.
-     */
-    onAnimEnd(action: (anim: string) => void): EventController;
-    /**
-     * @since v3000.0
-     */
-    renderArea(): Rect;
-}
-
-/**
- * Component to draw a text.
- *
- * @group Component System
- */
-export interface TextComp extends Comp {
-    draw: Comp["draw"];
-    /**
-     * The text to render.
-     */
-    text: string;
-    /**
-     * The text size.
-     */
-    textSize: number;
-    /**
-     * The font to use.
-     */
-    font: string | BitmapFontData;
-    /**
-     * Width of text.
-     */
-    width: number;
-    /**
-     * Height of text.
-     */
-    height: number;
-    /**
-     * Text alignment ("left", "center" or "right", default "left").
-     *
-     * @since v3000.0
-     */
-    align: TextAlign;
-    /**
-     * The gap between each line.
-     *
-     * @since v2000.2
-     */
-    lineSpacing: number;
-    /**
-     * The gap between each character.
-     *
-     * @since v2000.2
-     */
-    letterSpacing: number;
-    /**
-     * Transform the pos, scale, rotation or color for each character based on the index or char.
-     *
-     * @since v2000.1
-     */
-    textTransform: CharTransform | CharTransformFunc;
-    /**
-     * Stylesheet for styled chunks, in the syntax of "this is a [style]text[/style] word".
-     *
-     * @since v2000.2
-     */
-    textStyles: Record<string, CharTransform | CharTransformFunc>;
-    /**
-     * @since v3000.0
-     */
-    renderArea(): Rect;
-}
-
-/**
- * @group Options
- */
-export interface TextCompOpt {
-    /**
-     * Height of text.
-     */
-    size?: number;
-    /**
-     * The font to use.
-     */
-    font?: string | BitmapFontData;
-    /**
-     * Wrap text to a certain width.
-     */
-    width?: number;
-    /**
-     * Text alignment ("left", "center" or "right", default "left").
-     *
-     * @since v3000.0
-     */
-    align?: TextAlign;
-    /**
-     * The gap between each line.
-     *
-     * @since v2000.2
-     */
-    lineSpacing?: number;
-    /**
-     * The gap between each character.
-     *
-     * @since v2000.2
-     */
-    letterSpacing?: number;
-    /**
-     * Transform the pos, scale, rotation or color for each character based on the index or char.
-     *
-     * @since v2000.1
-     */
-    transform?: CharTransform | CharTransformFunc;
-    /**
-     * Stylesheet for styled chunks, in the syntax of "this is a [style]text[/style] word".
-     *
-     * @since v2000.2
-     */
-    styles?: Record<string, CharTransform | CharTransformFunc>;
-}
-
-/**
- * @group Options
- */
-export interface RectCompOpt {
-    /**
-     * Radius of the rectangle corners.
-     */
-    radius?: number;
-    /**
-     * If fill the rectangle (useful if you only want to render outline with outline() component).
-     */
-    fill?: boolean;
-}
-
-/**
- * @group Component System
- */
-export interface RectComp extends Comp {
-    draw: Comp["draw"];
-    /**
-     * Width of rectangle.
-     */
-    width: number;
-    /**
-     * Height of rectangle.
-     */
-    height: number;
-    /**
-     * The radius of each corner.
-     */
-    radius?: number;
-    /**
-     * @since v3000.0
-     */
-    renderArea(): Rect;
-}
-
-/**
- * @group Options
- */
-export type PolygonCompOpt = Omit<DrawPolygonOpt, "pts">;
-
-/**
- * Component to draw a polygon.
- *
- * @since v3001.0
- * @group Component System
- */
-export interface PolygonComp extends Comp {
-    draw: Comp["draw"];
-    /**
-     * Points in the polygon.
-     */
-    pts: Vec2[];
-    /**
-     * The radius of each corner.
-     */
-    radius?: number | number[];
-    /**
-     * The color of each vertex.
-     */
-    colors?: Color[];
-    /**
-     * The uv of each vertex.
-     *
-     * @since v3001.0
-     */
-    uv?: Vec2[];
-    /**
-     * The texture used when uv coordinates are present.
-     *
-     * @since v3001.0
-     */
-    tex?: Texture;
-    renderArea(): Polygon;
-}
-
-/**
- * @group Options
- */
-export interface CircleCompOpt {
-    /**
-     * If fill the circle (useful if you only want to render outline with outline() component).
-     */
-    fill?: boolean;
-}
-
-/**
- * @group Component System
- */
-export interface CircleComp extends Comp {
-    draw: Comp["draw"];
-    /**
-     * Radius of circle.
-     */
-    radius: number;
-    /**
-     * @since v3000.0
-     */
-    renderArea(): Rect;
-}
-
-/**
- * @group Component System
- */
-export interface UVQuadComp extends Comp {
-    draw: Comp["draw"];
-    /**
-     * Width of rect.
-     */
-    width: number;
-    /**
-     * Height of height.
-     */
-    height: number;
-    /**
-     * @since v3000.0
-     */
-    renderArea(): Rect;
-}
-
-/**
  * @group Draw
  */
 export type Shape =
@@ -6047,13 +5399,6 @@ export type Shape =
     | Circle
     | Ellipse
     | Polygon;
-
-/**
- * @group Component System
- */
-export interface OutlineComp extends Comp {
-    outline: Outline;
-}
 
 /**
  * @group Debug
@@ -6140,346 +5485,7 @@ export type UniformKey = Exclude<string, "u_tex">;
  */
 export type Uniform = Record<UniformKey, UniformValue>;
 
-/**
- * @group Component System
- */
-export interface ShaderComp extends Comp {
-    uniform: Uniform;
-    shader: string;
-}
-
-/**
- * @group Component System
- */
-export interface BodyComp extends Comp {
-    /**
-     * Object current velocity.
-     *
-     * @since v3001.0
-     */
-    vel: Vec2;
-    /**
-     * How much velocity decays (velocity *= (1 - drag) every frame).
-     *
-     * @since v3001.0
-     */
-    drag: number;
-    /**
-     * If object is static, won't move, and all non static objects won't move past it.
-     */
-    isStatic: boolean;
-    /**
-     * Initial speed in pixels per second for jump().
-     */
-    jumpForce: number;
-    /**
-     * Gravity multiplier.
-     */
-    gravityScale: number;
-    /**
-     * Mass of the body, decides how much a non-static body should move when resolves with another non-static body. (default 1).
-     *
-     * @since v3000.0
-     */
-    mass?: number;
-    /**
-     * If object should move with moving platform (default true).
-     *
-     * @since v3000.0
-     */
-    stickToPlatform?: boolean;
-    /**
-     * Current platform landing on.
-     */
-    curPlatform(): GameObj | null;
-    /**
-     * If currently landing on a platform.
-     *
-     * @since v2000.1
-     */
-    isGrounded(): boolean;
-    /**
-     * If currently falling.
-     *
-     * @since v2000.1
-     */
-    isFalling(): boolean;
-    /**
-     * If currently rising.
-     *
-     * @since v3000.0
-     */
-    isJumping(): boolean;
-    /**
-     * Upward thrust.
-     */
-    jump(force?: number): void;
-    /**
-     * Register an event that runs when a collision is resolved.
-     *
-     * @since v3000.0
-     */
-    onPhysicsResolve(action: (col: Collision) => void): EventController;
-    /**
-     * Register an event that runs before a collision would be resolved.
-     *
-     * @since v3000.0
-     */
-    onBeforePhysicsResolve(action: (col: Collision) => void): EventController;
-    /**
-     * Register an event that runs when the object is grounded.
-     *
-     * @since v2000.1
-     */
-    onGround(action: () => void): EventController;
-    /**
-     * Register an event that runs when the object starts falling.
-     *
-     * @since v2000.1
-     */
-    onFall(action: () => void): EventController;
-    /**
-     * Register an event that runs when the object falls off platform.
-     *
-     * @since v3000.0
-     */
-    onFallOff(action: () => void): EventController;
-    /**
-     * Register an event that runs when the object bumps into something on the head.
-     *
-     * @since v2000.1
-     */
-    onHeadbutt(action: () => void): EventController;
-}
-
-/**
- * @group Component System
- */
-export interface DoubleJumpComp extends Comp {
-    /**
-     * Number of jumps allowed.
-     */
-    numJumps: number;
-    /**
-     * Performs double jump (the initial jump only happens if player is grounded).
-     */
-    doubleJump(force?: number): void;
-    /**
-     * Register an event that runs when the object performs the second jump when double jumping.
-     */
-    onDoubleJump(action: () => void): EventController;
-}
-
-/**
- * @group Options
- */
-export interface BodyCompOpt {
-    /**
-     * How much velocity decays (velocity *= (1 - drag) every frame).
-     *
-     * @since v3001.0
-     */
-    drag?: number;
-    /**
-     * Initial speed in pixels per second for jump().
-     */
-    jumpForce?: number;
-    /**
-     * Maximum velocity when falling.
-     */
-    maxVelocity?: number;
-    /**
-     * Gravity multiplier.
-     */
-    gravityScale?: number;
-    /**
-     * If object is static, won't move, and all non static objects won't move past it.
-     *
-     * @since v3000.0
-     */
-    isStatic?: boolean;
-    /**
-     * If object should move with moving platform (default true).
-     *
-     * @since v3000.0
-     */
-    stickToPlatform?: boolean;
-    /**
-     * Mass of the body, decides how much a non-static body should move when resolves with another non-static body. (default 1).
-     *
-     * @since v3000.0
-     */
-    mass?: number;
-}
-
-/**
- * @group Component System
- */
-export interface TimerComp extends Comp {
-    /**
-     * Run the callback after n seconds.
-     */
-    wait(time: number, action?: () => void): TimerController;
-    /**
-     * Run the callback every n seconds.
-     *
-     * @since v3000.0
-     */
-    loop(time: number, action: () => void): EventController;
-    /**
-     * Tweeeeen! Note that this doesn't specifically mean tweening on this object's property, this just registers the timer on this object, so the tween will cancel with the object gets destroyed, or paused when obj.paused is true.
-     *
-     * @since v3000.0
-     */
-    tween<V extends LerpValue>(
-        from: V,
-        to: V,
-        duration: number,
-        setValue: (value: V) => void,
-        easeFunc?: (t: number) => number,
-    ): TweenController;
-}
-
-/**
- * @group Component System
- */
-export interface FixedComp extends Comp {
-    /**
-     * If the obj is unaffected by camera
-     */
-    fixed: boolean;
-}
-
-/**
- * @group Component System
- */
-export interface StayComp extends Comp {
-    /**
-     * If the obj should not be destroyed on scene switch.
-     */
-    stay: boolean;
-    /**
-     * Array of scenes that the obj will stay on.
-     */
-    scenesToStay: string[];
-}
-
-/**
- * @group Component System
- */
-export interface HealthComp extends Comp {
-    /**
-     * Decrease HP by n (defaults to 1).
-     */
-    hurt(n?: number): void;
-    /**
-     * Increase HP by n (defaults to 1).
-     */
-    heal(n?: number): void;
-    /**
-     * Current health points.
-     */
-    hp(): number;
-    /**
-     * Set current health points.
-     */
-    setHP(hp: number): void;
-    /**
-     * Max amount of HP.
-     */
-    maxHP(): number | null;
-    /**
-     * Set max amount of HP.
-     */
-    setMaxHP(hp: number): void;
-    /**
-     * Register an event that runs when hurt() is called upon the object.
-     *
-     * @since v2000.1
-     */
-    onHurt(action: (amount?: number) => void): EventController;
-    /**
-     * Register an event that runs when heal() is called upon the object.
-     *
-     * @since v2000.1
-     */
-    onHeal(action: (amount?: number) => void): EventController;
-    /**
-     * Register an event that runs when object's HP is equal or below 0.
-     *
-     * @since v2000.1
-     */
-    onDeath(action: () => void): EventController;
-}
-
-/**
- * @group Options
- */
-export interface LifespanCompOpt {
-    /**
-     * Fade out duration (default 0 which is no fade out).
-     */
-    fade?: number;
-}
-
-export interface NamedComp extends Comp {
-    /**
-     * The name assigned to this object.
-     */
-    name: string;
-}
-
-/**
- * @group Component System
- */
-export interface StateComp extends Comp {
-    /**
-     * Current state.
-     */
-    state: string;
-    /**
-     * Enter a state, trigger onStateEnd for previous state and onStateEnter for the new State state.
-     */
-    enterState: (state: string, ...args: any) => void;
-    /**
-     * Register event that runs once when a specific state transition happens. Accepts arguments passed from `enterState(name, ...args)`.
-     *
-     * @since v2000.2
-     */
-    onStateTransition(
-        from: string,
-        to: string,
-        action: () => void,
-    ): EventController;
-    /**
-     * Register event that runs once when enters a specific state. Accepts arguments passed from `enterState(name, ...args)`.
-     */
-    onStateEnter: (
-        state: string,
-        action: (...args: any) => void,
-    ) => EventController;
-    /**
-     * Register an event that runs once when leaves a specific state.
-     */
-    onStateEnd: (state: string, action: () => void) => EventController;
-    /**
-     * Register an event that runs every frame when in a specific state.
-     */
-    onStateUpdate: (state: string, action: () => void) => EventController;
-    /**
-     * Register an event that runs every frame when in a specific state.
-     */
-    onStateDraw: (state: string, action: () => void) => EventController;
-}
-
 export type Mask = "intersect" | "subtract";
-
-/**
- * @group Component System
- */
-export interface MaskComp extends Comp {
-    mask: Mask;
-}
 
 /**
  * @group Options
@@ -6541,63 +5547,7 @@ export enum EdgeMask {
 }
 
 /**
- * The options of a tile component
- *
- * @group Options
- */
-export type TileCompOpt = {
-    /**
-     * If the tile is an obstacle in pathfinding.
-     */
-    isObstacle?: boolean;
-    /**
-     * How much a tile is cost to traverse in pathfinding (default 0).
-     */
-    cost?: number;
-    /**
-     * If the tile has hard edges that cannot pass in pathfinding.
-     */
-    edges?: Edge[];
-    /**
-     * Position offset when setting `tilePos`.
-     */
-    offset?: Vec2;
-};
-
-/**
- * @group Component System
- */
-export interface TileComp extends Comp {
-    /**
-     * The tile position inside the level.
-     */
-    tilePos: Vec2;
-    /**
-     * If the tile is an obstacle in pathfinding.
-     */
-    isObstacle: boolean;
-    /**
-     * How much a tile is cost to traverse in pathfinding (default 0).
-     */
-    cost: number;
-    /**
-     * If the tile has hard edges that cannot pass in pathfinding.
-     */
-    edges: Edge[];
-    /**
-     * Position offset when setting `tilePos`.
-     */
-    tilePosOffset: Vec2;
-    readonly edgeMask: EdgeMask;
-    getLevel(): GameObj<LevelComp>;
-    moveLeft(): void;
-    moveRight(): void;
-    moveUp(): void;
-    moveDown(): void;
-}
-
-/**
- * @group Component System
+ * @group Components
  */
 export interface LevelComp extends Comp {
     tileWidth(): number;
@@ -6665,34 +5615,6 @@ export interface LevelComp extends Comp {
 export type PathFindOpt = {
     allowDiagonals?: boolean;
 };
-
-/**
- * @group Options
- */
-export type AgentCompOpt = {
-    speed?: number;
-    allowDiagonals?: boolean;
-};
-
-/**
- * @group Component System
- */
-export interface AgentComp extends Comp {
-    agentSpeed: number;
-    allowDiagonals: boolean;
-    getDistanceToTarget(): number;
-    getNextLocation(): Vec2 | null;
-    getPath(): Vec2[] | null;
-    getTarget(): Vec2 | null;
-    isNavigationFinished(): boolean;
-    isTargetReachable(): boolean;
-    isTargetReached(): boolean;
-    setTarget(target: Vec2): void;
-    onNavigationStarted(cb: () => void): EventController;
-    onNavigationNext(cb: () => void): EventController;
-    onNavigationEnded(cb: () => void): EventController;
-    onTargetReached(cb: () => void): EventController;
-}
 
 /**
  * @group Options


### PR DESCRIPTION
- moves components interfaces/opt to their modules in `components/`
- removes getInternalContext in favour of `const {} = k._k`
- moved raycast to components (again)
- this doesn't remove even the 10% of the line count in types.ts