### PR TITLE
docs: fixed scenename in types.ts

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1416,7 +1416,6 @@ export interface KaboomCtx<
      */
     onSceneLeave(action: (newScene?: string) => void): EventController;
     /**
-    /**
      * Gets the name of the current scene.
      *
      * @since v3001.0


### PR DESCRIPTION
![image](https://github.com/marklovers/kaplay/assets/92493175/068da366-d505-4167-8af2-8b5cb1d661c2)
