### PR TITLE
fix: Checks implicitly ensure values 

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -378,12 +378,12 @@ const kaplay = <
 
     // adjust canvas size according to user size / viewport settings
     if (fixedSize) {
-        canvas.width = gopt.width * gscale;
-        canvas.height = gopt.height * gscale;
-    } else {
-        canvas.width = canvas.parentElement.offsetWidth;
-        canvas.height = canvas.parentElement.offsetHeight;
-    }
+		canvas.width = gopt.width! * gscale
+		canvas.height = gopt.height! * gscale
+	} else {
+		canvas.width = canvas.parentElement!.offsetWidth
+		canvas.height = canvas.parentElement!.offsetHeight
+	}
 
     // canvas css styles
     const styles = [

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -378,12 +378,12 @@ const kaplay = <
 
     // adjust canvas size according to user size / viewport settings
     if (fixedSize) {
-		canvas.width = gopt.width! * gscale
-		canvas.height = gopt.height! * gscale
-	} else {
-		canvas.width = canvas.parentElement!.offsetWidth
-		canvas.height = canvas.parentElement!.offsetHeight
-	}
+        canvas.width = gopt.width! * gscale;
+        canvas.height = gopt.height! * gscale;
+    } else {
+        canvas.width = canvas.parentElement!.offsetWidth;
+        canvas.height = canvas.parentElement!.offsetHeight;
+    }
 
     // canvas css styles
     const styles = [


### PR DESCRIPTION
## Description

Use `!` for implicitly not falsey on canvas size check.

### Issues or related

Causes type issues.