### PR TITLE
fix: Ensure `gl` is defined.

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -434,7 +434,7 @@ const kaplay = <
 
     const gc: Array<() => void> = [];
 
-    const gl = app.canvas
+    const gl: WebGLRenderingContext = app.canvas
         .getContext("webgl", {
             antialias: true,
             depth: true,
@@ -443,7 +443,7 @@ const kaplay = <
             preserveDrawingBuffer: true,
         });
 
-    if (!gl && gl === null) throw new Error("WebGL not supported")
+    if (!gl || gl === null) throw new Error("WebGL not supported")
 
     const ggl = initGfx(gl, {
         texFilter: gopt.texFilter,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -443,7 +443,7 @@ const kaplay = <
             preserveDrawingBuffer: true,
         });
 
-    if (!gl) throw new Error("WebGL not supported")
+    if (!gl && gl !== null) throw new Error("WebGL not supported")
 
     const ggl = initGfx(gl, {
         texFilter: gopt.texFilter,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -443,7 +443,7 @@ const kaplay = <
             preserveDrawingBuffer: true,
         });
 
-    if (!gl && gl !== null) throw new Error("WebGL not supported")
+    if (!gl && gl === null) throw new Error("WebGL not supported")
 
     const ggl = initGfx(gl, {
         texFilter: gopt.texFilter,

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -443,6 +443,8 @@ const kaplay = <
             preserveDrawingBuffer: true,
         });
 
+    if (!gl) throw new Error("WebGL not supported")
+
     const ggl = initGfx(gl, {
         texFilter: gopt.texFilter,
     });

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -441,9 +441,9 @@ const kaplay = <
             stencil: true,
             alpha: true,
             preserveDrawingBuffer: true,
-        });
+        })!;
 
-    if (!gl || gl === null) throw new Error("WebGL not supported")
+    if (!gl || gl === null) throw new Error("WebGL not supported");
 
     const ggl = initGfx(gl, {
         texFilter: gopt.texFilter,


### PR DESCRIPTION
## Description

Ensure GL is defined.

### Issues or related

When no GL context is passed, WebGL is likely to be unsupported.