### PR TITLE
fix: Implicitly set to null, needs to also be null case.

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -576,7 +576,7 @@ const kaplay = <
             tex: Texture,
             frames?: Quad[],
             anims: SpriteAnims = {},
-            slice9: NineSlice = null,
+            slice9: NineSlice | null = null,
         ) {
             this.tex = tex;
             if (frames) this.frames = frames;


### PR DESCRIPTION
## Description

`slice9` arg is null, so must have null type to match class.

### Issues or related

Type collision.