### PR TITLE
fix: if createSpriteSheet ctx fails, throw, else ensure defined

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -916,7 +916,7 @@ const kaplay = <
         canvas.width = width * images.length;
         canvas.height = height;
         const c2d = canvas.getContext("2d");
-		if (!c2d) throw new Error("Failed to create canvas context");
+	if (!c2d) throw new Error("Failed to create canvas context");
         images.forEach((img, i) => {
             if (img instanceof ImageData) {
                 c2d.putImageData(img, i * width, 0);

--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -916,6 +916,7 @@ const kaplay = <
         canvas.width = width * images.length;
         canvas.height = height;
         const c2d = canvas.getContext("2d");
+		if (!c2d) throw new Error("Failed to create canvas context");
         images.forEach((img, i) => {
             if (img instanceof ImageData) {
                 c2d.putImageData(img, i * width, 0);


### PR DESCRIPTION
## Description

if createSpriteSheet ctx fails, throw, else ensure defined.

### Issues or related

Type collision.