### PR TITLE
fix: `resolveFont` passes null, add null FN Return type

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -1205,6 +1205,7 @@ const kaplay = <
         | BitmapFontData
         | Asset<BitmapFontData>
         | string
+        | null
         | void
     {
         if (!src) {


### PR DESCRIPTION
## Description

fix: `resolveFont` passes null, add null FN Return type

### Issues or related

Type collision.