### PR TITLE
fix: Ensure `postShader` & `postShaderUniform` is typed

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -539,8 +539,8 @@ const kaplay = <
             defShader: defShader,
             defTex: emptyTex,
             frameBuffer: frameBuffer,
-            postShader: null,
-            postShaderUniform: null,
+            postShader: null as string | null,
+            postShaderUniform: null as Uniform | (() => Uniform) | null,
             renderer: renderer,
 
             transform: new Mat4(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -4498,8 +4498,8 @@ export interface RenderProps {
     color?: Color;
     opacity?: number;
     fixed?: boolean;
-    shader?: string | ShaderData | Asset<ShaderData>;
-    uniform?: Uniform;
+    shader?: string | ShaderData | Asset<ShaderData> | null;
+    uniform?: Uniform | null;
     outline?: Outline;
 }
 


### PR DESCRIPTION
## Description

Ensure `postShader` & `postShaderUniform` is typed

### Issues or related

Type collision.