### PR TITLE
bugfix: ensure loading sprite on load doesn't crash

### DIFF
--- a/src/components/draw/sprite.ts
+++ b/src/components/draw/sprite.ts
@@ -271,7 +271,9 @@ export function sprite(
         },
 
         add(this: GameObj<SpriteComp>) {
-            const setSpriteData = (spr) => {
+            const setSpriteData = (spr: SpriteData | null) => {
+                if (!spr) return;
+                
                 let q = spr.frames[0].clone();
 
                 if (opt.quad) {


### PR DESCRIPTION
## Description

ensure loading sprite on load doesn't crash

### Issues or related

> Will not throw, we will just have to return before we put any data
cause it'll do it again when the sprite promise finishes
Because what was happening before is that it'll do that, fail, and then crash after the first prop access