### PR TITLE
fix: `getCost` expects `costMap`

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4508,7 +4508,7 @@ const kaplay = <
 
         const getCost = (node: number, neighbour: number) => {
             // Cost of destination tile
-            return costMap[neighbour];
+            return costMap![neighbour];
         };
 
         const getHeuristic = (node: number, goal: number) => {


### PR DESCRIPTION
## Description

`getCost` expects `costMap`

### Issues or related

Type collision.