### PR TITLE
fix: `getSpatialMap` expects result to be made after check

### DIFF
--- a/src/kaboom.ts
+++ b/src/kaboom.ts
@@ -4671,7 +4671,7 @@ const kaplay = <
                 if (!spatialMap) {
                     createSpatialMap();
                 }
-                return spatialMap;
+                return spatialMap!;
             },
 
             onSpatialMapChanged(this: GameObj<LevelComp>, cb: () => void) {


### PR DESCRIPTION
## Description

getSpatialMap expects result to be made after check 

### Issues or related

Type collision