### PR TITLE
fix: new ctx, multiboom

### DIFF
--- a/examples/multiboom.js
+++ b/examples/multiboom.js
@@ -32,8 +32,9 @@ for (let i = 0; i < 2; i++) {
     }
 
     k.add([
-        k.circle(40),
+        k.rect(40, 30),
         k.anchor("center"),
+        spin(),
         k.pos(
             positions[i][0],
             positions[i][1],

--- a/src/components/draw/rect.ts
+++ b/src/components/draw/rect.ts
@@ -1,3 +1,4 @@
+import { withKaboomCtx } from "../../core/context";
 import { getKaboomContext } from "../../kaboom";
 import { Rect, vec2 } from "../../math";
 import type { Comp, GameObj, KaboomCtx } from "../../types";
@@ -43,35 +44,32 @@ export interface RectCompOpt {
     fill?: boolean;
 }
 
-export function rect(
-    this: KaboomCtx,
-    w: number,
-    h: number,
-    opt: RectCompOpt = {},
-): RectComp {
-    const k = getKaboomContext(this);
-    const { getRenderProps } = k._k;
+export const ctxRect = withKaboomCtx(
+    function(kCtx, w: number, h: number, opt: RectCompOpt = {}): RectComp {
+        const k = kCtx;
+        const { getRenderProps } = k._k;
 
-    return {
-        id: "rect",
-        width: w,
-        height: h,
-        radius: opt.radius || 0,
-        draw(this: GameObj<RectComp>) {
-            k.drawRect(Object.assign(getRenderProps(this), {
-                width: this.width,
-                height: this.height,
-                radius: this.radius,
-                fill: opt.fill,
-            }));
-        },
-        renderArea() {
-            return new Rect(vec2(0), this.width, this.height);
-        },
-        inspect() {
-            return `rect: (${Math.ceil(this.width)}w, ${
-                Math.ceil(this.height)
-            }h)`;
-        },
-    };
-}
+        return {
+            id: "rect",
+            width: w,
+            height: h,
+            radius: opt.radius || 0,
+            draw(this: GameObj<RectComp>) {
+                k.drawRect(Object.assign(getRenderProps(this), {
+                    width: this.width,
+                    height: this.height,
+                    radius: this.radius,
+                    fill: opt.fill,
+                }));
+            },
+            renderArea() {
+                return new Rect(vec2(0), this.width, this.height);
+            },
+            inspect() {
+                return `rect: (${Math.ceil(this.width)}w, ${
+                    Math.ceil(this.height)
+                }h)`;
+            },
+        };
+    },
+);

--- a/src/core/context.ts
+++ b/src/core/context.ts
@@ -1,0 +1,109 @@
+import type { App } from "../app";
+import type { AppGfxCtx } from "../gfx";
+import { type KaboomCtx } from "../kaboom";
+
+type ParametersOmitFirst<T extends (x: any, ...args: any) => any> = T extends
+    (x: any, ...args: infer P) => any ? P : never;
+
+type ParametersOmitFirst2<T extends (x: any, y: any, ...args: any) => any> =
+    T extends (x: any, y: any, ...args: infer P) => any ? P : never;
+
+type Wrapper<T> = {
+    current: T | null;
+};
+
+// This works for methods, component that uses the components, this means
+// is executed after kaplay() is called. If context doesn't exist,
+// it will throw an error
+export const withKaboomCtx = <
+    T extends (k: KaboomCtx, ...args: any[]) => any,
+    R extends ReturnType<T>,
+>(
+    func: T,
+) => {
+    return (k: Wrapper<KaboomCtx>): (
+        ...args: ParametersOmitFirst<T>
+    ) => R => {
+        return (...args: ParametersOmitFirst<T>) => {
+            if (!k.current) {
+                throw new Error(
+                    "Tried to use kaboom context before it was created.",
+                );
+            }
+
+            return func(k.current, ...args);
+        };
+    };
+};
+
+// This works for methods that are created before kaplay() is called,
+// but after app is created, for example make().
+export const withApp = <
+    T extends (app: App, ...args: any[]) => any,
+    R extends ReturnType<T>,
+>(
+    func: T,
+) => {
+    return (app: App): (
+        ...args: ParametersOmitFirst<T>
+    ) => R => {
+        return (...args: ParametersOmitFirst<T>) => {
+            return func(app, ...args);
+        };
+    };
+};
+
+// This works for access gfx before kaplay() is called,
+// but after gfx is created.
+export const withGfx = <
+    T extends (gfx: AppGfxCtx, ...args: any[]) => any,
+    R extends ReturnType<T>,
+>(
+    func: T,
+) => {
+    return (gfx: AppGfxCtx): (
+        ...args: ParametersOmitFirst<T>
+    ) => R => {
+        return (...args: ParametersOmitFirst<T>) => {
+            return func(gfx, ...args);
+        };
+    };
+};
+
+export const withAppAndKaboom = <
+    T extends (app: App, k: KaboomCtx, ...args: any[]) => any,
+    R extends ReturnType<T>,
+>(func: T) => {
+    return (app: App, k: Wrapper<KaboomCtx>): (
+        ...args: ParametersOmitFirst2<T>
+    ) => R => {
+        return (...args: ParametersOmitFirst2<T>) => {
+            if (!k.current) {
+                throw new Error(
+                    "Tried to use kaboom context before it was created.",
+                );
+            }
+
+            return func(app, k.current, ...args);
+        };
+    };
+};
+
+export const withGfxAndKaboom = <
+    T extends (gfx: AppGfxCtx, k: KaboomCtx, ...args: any[]) => any,
+    R extends ReturnType<T>,
+>(func: T) => {
+    return (gfx: AppGfxCtx, k: Wrapper<KaboomCtx>): (
+        ...args: ParametersOmitFirst2<T>
+    ) => R => {
+        return (...args: ParametersOmitFirst2<T>) => {
+            if (!k.current) {
+                throw new Error(
+                    "Tried to use kaboom context before it was created.",
+                );
+            }
+
+            return func(gfx, k.current, ...args);
+        };
+    };
+};

--- a/src/gfx/draw.ts
+++ b/src/gfx/draw.ts
@@ -1,10 +1,12 @@
+import { withGfxAndKaboom } from "../core/context";
 import { getKaboomContext } from "../kaboom";
 import type { RenderProps, Texture, Uniform, Vertex } from "../types";
 import { Asset } from "./assets";
 import { resolveShader } from "./shader";
 
-export function drawRaw(
-    this: any,
+export const ctxDrawRaw = withGfxAndKaboom(function(
+    gfx,
+    k,
     verts: Vertex[],
     indices: number[],
     fixed: boolean = false,
@@ -12,13 +14,12 @@ export function drawRaw(
     shaderSrc?: RenderProps["shader"],
     uniform: Uniform = {},
 ) {
-    const ctx = getKaboomContext(this);
-    const { _k } = ctx;
-    const { game, gfx, screen2ndc } = _k;
+    const { _k } = k;
+    const { game, screen2ndc } = _k;
 
     const parsedTex = tex ?? gfx.defTex;
     const parsedShader = shaderSrc ?? gfx.defShader;
-    const shader = resolveShader(ctx, parsedShader);
+    const shader = resolveShader(k, parsedShader);
 
     if (!shader || shader instanceof Asset) {
         return;
@@ -53,4 +54,4 @@ export function drawRaw(
         parsedTex,
         uniform,
     );
-}
+});

--- a/src/gfx/gfxApp.ts
+++ b/src/gfx/gfxApp.ts
@@ -103,7 +103,7 @@ export const initAppGfx = (gopt: KaboomOpt, ggl: GfxCtx) => {
         },
     );
 
-    const gfx = {
+    return {
         // how many draw calls we're doing last frame, this is the number we give to users
         lastDrawCalls: 0,
         ggl,
@@ -137,6 +137,4 @@ export const initAppGfx = (gopt: KaboomOpt, ggl: GfxCtx) => {
 
         fixed: false,
     };
-
-    return gfx;
 };

--- a/src/gfx/index.ts
+++ b/src/gfx/index.ts
@@ -1,5 +1,6 @@
 export * from "./anchor";
 export * from "./assets";
+export * from "./draw";
 export * from "./fonts";
 export * from "./gfx";
 export * from "./gfxApp";

--- a/src/gfx/push.ts
+++ b/src/gfx/push.ts
@@ -1,63 +1,43 @@
-import { getKaboomContext, type KaboomCtx } from "../kaboom";
+import { withGfx } from "../core/context";
 import { type Mat4, vec2, type Vec2Args } from "../math";
 
-export function pushTranslate(
-    this: KaboomCtx,
-    ...args: Vec2Args | [undefined]
-) {
-    const { _k } = getKaboomContext(this);
-    const { gfx } = _k;
+export const ctxPushTranslate = withGfx(
+    function(gfx, ...args: Vec2Args | [undefined]) {
+        if (args[0] === undefined) return;
 
-    if (args[0] === undefined) return;
+        const p = vec2(...args);
+        if (p.x === 0 && p.y === 0) return;
+        gfx.transform.translate(p);
+    },
+);
 
-    const p = vec2(...args);
-    if (p.x === 0 && p.y === 0) return;
-    gfx.transform.translate(p);
-}
-
-export function pushTransform(this: KaboomCtx) {
-    const { _k } = getKaboomContext(this);
-    const { gfx } = _k;
-
+export const ctxPushTransform = withGfx(function(gfx) {
     gfx.transformStack.push(gfx.transform.clone());
-}
+});
 
-export function pushMatrix(this: KaboomCtx, m: Mat4) {
-    const { _k } = getKaboomContext(this);
-    const { gfx } = _k;
-
+export const ctxPushMatrix = withGfx(function(gfx, m: Mat4) {
     gfx.transform = m.clone();
-}
+});
 
-export function pushScale(
-    this: KaboomCtx,
-    ...args: Vec2Args | [undefined] | [undefined, undefined]
-) {
-    if (args[0] === undefined) return;
+export const ctxPushScale = withGfx(
+    function(gfx, ...args: Vec2Args | [undefined] | [undefined, undefined]) {
+        if (args[0] === undefined) return;
 
-    const { _k } = getKaboomContext(this);
-    const { gfx } = _k;
+        const p = vec2(...args);
+        if (p.x === 1 && p.y === 1) return;
+        gfx.transform.scale(p);
+    },
+);
 
-    const p = vec2(...args);
-    if (p.x === 1 && p.y === 1) return;
-    gfx.transform.scale(p);
-}
-
-export function pushRotate(this: KaboomCtx, a: number | undefined) {
+export const ctxPushRotate = withGfx(function(gfx, a: number | undefined) {
     if (!a) return;
 
-    const { _k } = getKaboomContext(this);
-    const { gfx } = _k;
-
     gfx.transform.rotate(a);
-}
+});
 
-export function popTransform(this: KaboomCtx) {
-    const { _k } = getKaboomContext(this);
-    const { gfx } = _k;
-
+export const ctxPopTransform = withGfx(function(gfx) {
     if (gfx.transformStack.length > 0) {
         // if there's more than 1 element, it will return obviously a Mat4
         gfx.transform = gfx.transformStack.pop()!;
     }
-}
+});


### PR DESCRIPTION
## Description
In one of my previous PR I broke compatibility between various kaplay instances, so I added a new way to handle context.

In kaplay() function, there's some core parts of our game

```js
const app = initApp();
const gfx = initGfx();
```

And some functions (that before was inside kaplay()) used this context

```js
function pushTransform() {
    gfx.transformStack.push(gfx.transform.clone());
}
```

This function `depends` of gfx variable, and then is exported to the kaplay context.

But when we advance with modulization, gfx is still inside `kaplay()`, but now pushTransform is in another file. A previous solution was use `getKaboomContext`.

```js
export function pushTransform() {
    const { _k } = getKaboomContext(this);
    const { gfx } = _k;
 
    gfx.transformStack.push(gfx.transform.clone());
}
```

Being this the ctx itself, when using `k.` prefix, if not it returns a global context instance. The problem comes when you try to use this with not context functions, for example `drawRaw`, used internally for all drawing.

So, if this is not the Kaboom context, it is the window object or null. And this was making multiboom fail, because `drawRaw` was using context. 

In general, I wanted to do something better than this solution.

## New context system

The new context system consist in create the functions inside `kaplay()`, but the code itself can be in another file.

```js
export const ctxPushTranslate = withGfx(
    function(gfx, ...args: Vec2Args | [undefined]) {
        if (args[0] === undefined) return;

        const p = vec2(...args);
        if (p.x === 0 && p.y === 0) return;
        gfx.transform.translate(p);
    },
);
```

After this, we "instance" the function inside `kaplay()` callback

```js
const gfx = initAppGfx(gopt, ggl);

// gfx dependants
const pushTranslate = ctxPushTranslate(gfx);
```

And we got pushTranslate original function, even with the original types, and removing the neccesity of pass gfx. Then we export this in the KAPLAY Context.

The same with dependants of app, or even the kaboom context itself. As always, if is tried to use the context before it creation (before `kaplay()` call) will throw an error. 

```js
const rect = ctxRect(ctxWrapper);
```

Specifically the `withKaboomCtx`, it's used a wrapper object, because it can exist or nop. If it doesn't exist, will throw an error, because you shouldn't use kaboom context before `kaplay()` callback. 

With this merged, we can start migrating our `getKaboomContext` to `withKaboomCtx`, `withAppCtx`, `withGfxCtx` or any other form. The idea is remove eventually `getKaboomContext` and even the internal context, because most of the internal context usage are only to use that variables like `app`, `game` or `gfx` 


