### PR TITLE
feat: support stacking text styles

### DIFF
--- a/examples/text.js
+++ b/examples/text.js
@@ -106,15 +106,17 @@ onKeyDown("down", () => {
 
 // Use this syntax and style option to style chunks of text, with CharTransformFunc.
 add([
-    text("[green]oh hi[/green] here's some [wavy]styled[/wavy] text", {
+    text("[green]oh hi[/green] here's some [wavy][rainbow]styled[/rainbow][/wavy] text", {
         width: width(),
         styles: {
             "green": {
                 color: rgb(128, 128, 255),
             },
             "wavy": (idx, ch) => ({
-                color: hsl2rgb((time() * 0.2 + idx * 0.1) % 1, 0.7, 0.8),
                 pos: vec2(0, wave(-4, 4, time() * 6 + idx * 0.5)),
+            }),
+            "rainbow": (idx, ch) => ({
+                color: hsl2rgb((time() * 0.2 + idx * 0.1) % 1, 0.7, 0.8),
             }),
         },
     }),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -95,6 +95,7 @@ export const COMP_EVENTS = new Set([
     "inspect",
     "drawInspect",
 ]);
+export const MULTI_WORD_RE = /^\w+$/;
 export const DEF_OFFSCREEN_DIS = 200;
 // maximum y velocity with body()
 export const DEF_JUMP_FORCE = 640;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -95,9 +95,6 @@ export const COMP_EVENTS = new Set([
     "inspect",
     "drawInspect",
 ]);
-// TODO: escape
-// eslint-disable-next-line
-export const TEXT_STYLE_RE = /\[(?<style>\w+)\](?<text>.*?)\[\/\k<style>\]/g;
 export const DEF_OFFSCREEN_DIS = 200;
 // maximum y velocity with body()
 export const DEF_JUMP_FORCE = 640;


### PR DESCRIPTION
## Add support for stacking styles in the `text()` component

Previously, stacking multiple styles (e.g., `[wavy][rainbow]styled[/rainbow][/wavy]`) would result in text being styled with only the outer-most style tag (in this case, `[wavy]`). This PR changes the inner logic of `compileStyledText` to correctly apply all nested styles.

### Issues or related

- Closes #124
