### PR TITLE
chore: fix typo in add example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 1. Pick on example to test and edit the corresponding `/examples/[name].js`, or
    create a new file under `/examples` to test anything you're working on.
-1. The source entry point is `src/kaaplay.ts`, editing any files referenced will
+1. The source entry point is `src/kaplay.ts`, editing any files referenced will
    automatically trigger rebuild. **Make sure not to break any existing
    examples**.
 1. Run `pnpm dev` to start the dev server and try examples.

--- a/examples/add.js
+++ b/examples/add.js
@@ -1,13 +1,13 @@
 // Adding game objects to screen
 
-// Start a kaplay game
+// Start a KAPLAY game
 kaplay();
 
 // Load a sprite asset from "sprites/bean.png", with the name "bean"
 loadSprite("bean", "/sprites/bean.png");
 loadSprite("ghosty", "/sprites/ghosty.png");
 
-// A "Game Object" is the basic unit of entity in kaplay
+// A "Game Object" is the basic unit of entity in KAPLAY
 // Game objects are composed from components
 // Each component gives a game object certain capabilities
 

--- a/examples/add.js
+++ b/examples/add.js
@@ -1,13 +1,13 @@
 // Adding game objects to screen
 
-// Start a kaboom game
+// Start a kaplay game
 kaplay();
 
 // Load a sprite asset from "sprites/bean.png", with the name "bean"
 loadSprite("bean", "/sprites/bean.png");
 loadSprite("ghosty", "/sprites/ghosty.png");
 
-// A "Game Object" is the basic unit of entity in kaboom
+// A "Game Object" is the basic unit of entity in kaplay
 // Game objects are composed from components
 // Each component gives a game object certain capabilities
 


### PR DESCRIPTION
it should be called `kaplay` instead of `kaboom` now, right ?